### PR TITLE
Feature/807 event features

### DIFF
--- a/packages/api/src/credentials/aws_credentials.rs
+++ b/packages/api/src/credentials/aws_credentials.rs
@@ -230,6 +230,7 @@ impl AwsRuntimeCredentials {
                 &runs_prefix,
                 &temporary_user_prefix,
                 &temporary_global_prefix,
+                meta_bucket_express_zone(),
             ),
             CredentialsAccess::ReadLogs => read_logs_policy(self, &runs_prefix),
         };
@@ -303,13 +304,27 @@ fn scoped_content_path_prefixes(
     (app, user)
 }
 
+/// Whether the meta bucket is an S3 Express directory bucket. On a directory
+/// bucket the CreateSession token — not per-object IAM — authorizes every
+/// zonal request, so the two bucket flavors need disjoint policy statements.
+/// Emitting both flavors in one session policy pushed AssumeRole past its
+/// packed-policy budget (PackedPolicyTooLargeException at dispatch).
+/// Deployment configuration never changes within a process, so the env var is
+/// read once.
+fn meta_bucket_express_zone() -> bool {
+    static META_BUCKET_EXPRESS_ZONE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *META_BUCKET_EXPRESS_ZONE.get_or_init(|| {
+        std::env::var("META_BUCKET_EXPRESS_ZONE")
+            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+            .unwrap_or(false)
+    })
+}
+
 #[cfg(feature = "aws")]
 #[async_trait]
 impl RuntimeCredentialsTrait for AwsRuntimeCredentials {
     fn into_shared_credentials(&self) -> SharedCredentials {
-        let meta_express = std::env::var("META_BUCKET_EXPRESS_ZONE")
-            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
-            .unwrap_or(false);
+        let meta_express = meta_bucket_express_zone();
         let content_express = std::env::var("CONTENT_BUCKET_EXPRESS_ZONE")
             .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
             .unwrap_or(false);
@@ -510,6 +525,7 @@ fn server_execute_policy(
     runs_prefix: &str,
     temporary_user_prefix: &str,
     temporary_global_prefix: &str,
+    meta_express: bool,
 ) -> flow_like_types::Value {
     // Draft artifacts (compiled boards, exact `.board` snapshots, prerun
     // manifests) live under `tmp/apps/{app_id}/` on the meta bucket so
@@ -517,121 +533,124 @@ fn server_execute_policy(
     // read-only grant there as on `apps/{app_id}` — only the API writes
     // drafts, which anchors `entry_authority_revision`.
     let draft_meta_prefix = format!("tmp/{apps_prefix}");
+    let mut statements = vec![
+        json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3:ListBucket"
+          ],
+          "Resource": [
+              format!("arn:aws:s3:::{}", credentials.content_bucket)
+          ],
+          "Condition": {
+              "StringLike": {
+                  "s3:prefix": [
+                      format!("{}/*", apps_prefix),
+                      format!("{}/*", user_prefix),
+                      format!("{}/*", temporary_user_prefix),
+                      format!("{}/*", temporary_global_prefix)
+                  ]
+              }
+          }
+        }),
+        json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3:GetObject",
+              "s3:PutObject",
+              "s3:DeleteObject"
+          ],
+          "Resource": [
+              format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, apps_prefix),
+              format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, user_prefix),
+              format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, temporary_user_prefix),
+              format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, temporary_global_prefix),
+          ],
+        }),
+        json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3:ListBucket"
+          ],
+          "Resource": [
+              format!("arn:aws:s3:::{}", credentials.logs_bucket)
+          ],
+          "Condition": {
+              "StringLike": {
+                  "s3:prefix": [
+                      format!("{}/*", runs_prefix)
+                  ]
+              }
+          }
+        }),
+        // Run logs are append-only: the executor creates and appends Lance
+        // tables (fresh data files, `.txn` files, conditional-put manifests)
+        // and never deletes; Lance's auto-cleanup is best-effort and logs on
+        // denial. Without DeleteObject a compromised run cannot erase or
+        // rewrite another run's audit trail.
+        json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3:GetObject",
+              "s3:PutObject"
+          ],
+          "Resource": [
+              format!("arn:aws:s3:::{}/{}/*", credentials.logs_bucket, runs_prefix),
+          ],
+        }),
+    ];
+    if meta_express {
+        // On a directory bucket the session token — not per-object IAM —
+        // authorizes every zonal request, so the `s3:*` meta statements would
+        // never be evaluated; emitting them anyway blew the AssumeRole packed
+        // policy budget. Pin the session to ReadOnly so this mode cannot
+        // write the meta bucket.
+        statements.push(json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3express:CreateSession",
+          ],
+          "Resource": [
+              "*"
+          ],
+          "Condition": {
+              "StringEquals": {
+                  "s3express:SessionMode": "ReadOnly"
+              }
+          }
+        }));
+    } else {
+        statements.push(json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3:ListBucket"
+          ],
+          "Resource": [
+              format!("arn:aws:s3:::{}", credentials.meta_bucket)
+          ],
+          "Condition": {
+              "StringLike": {
+                  "s3:prefix": [
+                      format!("{}/*", apps_prefix),
+                      format!("{}/*", draft_meta_prefix)
+                  ]
+              }
+          }
+        }));
+        statements.push(json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3:GetObject"
+          ],
+          "Resource": [
+              format!("arn:aws:s3:::{}/{}/*", credentials.meta_bucket, apps_prefix),
+              format!("arn:aws:s3:::{}/{}/*", credentials.meta_bucket, draft_meta_prefix),
+          ],
+        }));
+    }
     json!({
         "Version": "2012-10-17",
-        "Statement": [
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                format!("arn:aws:s3:::{}", credentials.content_bucket)
-            ],
-            "Condition": {
-                "StringLike": {
-                    "s3:prefix": [
-                        format!("{}/*", apps_prefix),
-                        format!("{}/*", user_prefix),
-                        format!("{}/*", temporary_user_prefix),
-                        format!("{}/*", temporary_global_prefix)
-                    ]
-                }
-            }
-          },
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:DeleteObject"
-            ],
-            "Resource": [
-                format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, apps_prefix),
-                format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, user_prefix),
-                format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, temporary_user_prefix),
-                format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, temporary_global_prefix),
-            ],
-          },
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                format!("arn:aws:s3:::{}", credentials.logs_bucket)
-            ],
-            "Condition": {
-                "StringLike": {
-                    "s3:prefix": [
-                        format!("{}/*", runs_prefix)
-                    ]
-                }
-            }
-          },
-          // Run logs are append-only: the executor creates and appends Lance
-          // tables (fresh data files, `.txn` files, conditional-put manifests)
-          // and never deletes; Lance's auto-cleanup is best-effort and logs on
-          // denial. Without DeleteObject a compromised run cannot erase or
-          // rewrite another run's audit trail.
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject"
-            ],
-            "Resource": [
-                format!("arn:aws:s3:::{}/{}/*", credentials.logs_bucket, runs_prefix),
-            ],
-          },
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                format!("arn:aws:s3:::{}", credentials.meta_bucket)
-            ],
-            "Condition": {
-                "StringLike": {
-                    "s3:prefix": [
-                        format!("{}/*", apps_prefix),
-                        format!("{}/*", draft_meta_prefix)
-                    ]
-                }
-            }
-          },
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject"
-            ],
-            "Resource": [
-                format!("arn:aws:s3:::{}/{}/*", credentials.meta_bucket, apps_prefix),
-                format!("arn:aws:s3:::{}/{}/*", credentials.meta_bucket, draft_meta_prefix),
-                format!("arn:aws:s3express:::{}/{}/*", credentials.meta_bucket, apps_prefix),
-                format!("arn:aws:s3express:::{}/{}/*", credentials.meta_bucket, draft_meta_prefix),
-            ],
-          },
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3express:CreateSession",
-            ],
-            "Resource": [
-                "*"
-            ],
-            // On a directory bucket the session token — not per-object IAM —
-            // authorizes every zonal request, and object_store asks for the
-            // maximum privilege. Pin the session to ReadOnly so this mode
-            // cannot write to the meta bucket.
-            "Condition": {
-                "StringEquals": {
-                    "s3express:SessionMode": "ReadOnly"
-                }
-            }
-          }
-        ],
+        "Statement": statements,
     })
 }
 
@@ -1284,6 +1303,7 @@ mod tests {
             "runs/app-1",
             "tmp/user/user-1/apps/app-1",
             "tmp/global/apps/app-1",
+            false,
         );
         let statements = policy["Statement"]
             .as_array()
@@ -1332,13 +1352,16 @@ mod tests {
         assert!(draft_artifact.starts_with("tmp/apps/app-1/"));
         assert!(!other_app_artifact.starts_with("tmp/apps/app-1/"));
         assert!(
-            meta_resources.contains("meta-secret/tmp/apps/app-1/*")
-                && meta_resources.contains("s3express:::meta-secret/tmp/apps/app-1/*"),
+            meta_resources.contains("meta-secret/tmp/apps/app-1/*"),
             "draft artifacts under tmp/apps must stay readable: {meta_resources}"
         );
         assert!(
             meta_list_prefixes.contains("tmp/apps/app-1/*"),
             "draft artifacts under tmp/apps must stay listable: {meta_list_prefixes}"
+        );
+        assert!(
+            !policy.to_string().contains("s3express"),
+            "a standard meta bucket needs no express statements"
         );
         assert!(policy.contains("content-data/apps/app-1/*"));
         assert!(policy.contains("logs/runs/app-1/*"));
@@ -1359,6 +1382,47 @@ mod tests {
         assert!(
             !meta_actions.contains("DeleteObject"),
             "ServerExecute must not grant meta deletes"
+        );
+    }
+
+    /// On an express meta bucket the CreateSession token authorizes every
+    /// zonal request, so the per-object meta statements are dead weight — and
+    /// carrying both flavors once pushed AssumeRole past its packed-policy
+    /// budget in production (PackedPolicyTooLargeException at dispatch).
+    #[test]
+    fn test_aws_server_execute_express_variant_stays_within_policy_budget() {
+        let creds = test_aws_runtime_credentials();
+        // Realistic id lengths: generated app ids and IdP subjects are long,
+        // and every prefix repeats them several times.
+        let app = "apps/v8f5p73w00itor03zlrai22w";
+        let user = "users/auth0|64c9f0aa11bb22cc33dd44ee/apps/v8f5p73w00itor03zlrai22w";
+        let runs = "runs/v8f5p73w00itor03zlrai22w";
+        let tmp_user = "tmp/user/auth0|64c9f0aa11bb22cc33dd44ee/apps/v8f5p73w00itor03zlrai22w";
+        let tmp_global = "tmp/global/apps/v8f5p73w00itor03zlrai22w";
+
+        let express = server_execute_policy(&creds, app, user, runs, tmp_user, tmp_global, true);
+        let express_json = to_string(&express).expect("policy should serialize");
+        assert!(
+            !express_json.contains("arn:aws:s3:::meta-secret"),
+            "express meta access flows through CreateSession, not per-object IAM"
+        );
+        assert!(express_json.contains("s3express:CreateSession"));
+        assert!(express_json.contains("ReadOnly"));
+
+        let standard = server_execute_policy(&creds, app, user, runs, tmp_user, tmp_global, false);
+        let standard_json = to_string(&standard).expect("policy should serialize");
+
+        // STS caps the plaintext at 2048 characters and packs it into a
+        // shared binary quota; both variants must keep real headroom.
+        assert!(
+            express_json.len() < 1600,
+            "express ServerExecute policy grew to {} chars",
+            express_json.len()
+        );
+        assert!(
+            standard_json.len() < 1900,
+            "standard ServerExecute policy grew to {} chars",
+            standard_json.len()
         );
     }
 
@@ -1392,6 +1456,7 @@ mod tests {
                 "runs/app-1",
                 "tmp/user/user-1/apps/app-1",
                 "tmp/global/apps/app-1",
+                true,
             ))
             .as_deref(),
             Some("\"ReadOnly\""),

--- a/packages/core/src/flow/compiled/prerun.rs
+++ b/packages/core/src/flow/compiled/prerun.rs
@@ -1022,21 +1022,31 @@ pub fn extract_page_execution(board: &Board, page: &Page) -> Result<PrerunPageEx
         optional_special_target(board, page, "unload", page.on_unload_event_id.as_deref())?;
     let interval = match page.on_interval_event_id.as_deref() {
         Some(node_id) if !node_id.is_empty() => {
-            validate_entry_node(board, &page.id, "special interval", node_id)?;
-            let seconds = page
-                .on_interval_seconds
-                .filter(|seconds| *seconds > 0)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "page '{}' configures interval node '{}' without a positive interval",
-                        page.id,
-                        node_id
-                    )
-                })?;
-            Some(PrerunPageIntervalEvent {
-                node_id: node_id.to_string(),
-                interval_seconds: Some(seconds),
-            })
+            // Tolerant like the other hooks: a stale target or broken period
+            // disables the interval instead of making the Page unloadable.
+            match validate_entry_node(board, &page.id, "special interval", node_id) {
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        "Skipping non-executable Page interval hook during extraction"
+                    );
+                    None
+                }
+                Ok(()) => match page.on_interval_seconds.filter(|seconds| *seconds > 0) {
+                    Some(seconds) => Some(PrerunPageIntervalEvent {
+                        node_id: node_id.to_string(),
+                        interval_seconds: Some(seconds),
+                    }),
+                    None => {
+                        tracing::warn!(
+                            page_id = %page.id,
+                            node_id,
+                            "Skipping Page interval hook without a positive period"
+                        );
+                        None
+                    }
+                },
+            }
         }
         _ => None,
     };
@@ -1872,7 +1882,12 @@ fn optional_special_target(
     let Some(node_id) = node_id.filter(|node_id| !node_id.is_empty()) else {
         return Ok(None);
     };
-    validate_entry_node(board, &page.id, &format!("special {kind}"), node_id)?;
+    // Same tolerance as `push_action`: a hook whose target left the board is
+    // disabled rather than making the Page unloadable.
+    if let Err(error) = validate_entry_node(board, &page.id, &format!("special {kind}"), node_id) {
+        tracing::warn!(%error, "Skipping non-executable Page lifecycle hook during extraction");
+        return Ok(None);
+    }
     Ok(Some(PrerunPageEventTarget {
         node_id: node_id.to_string(),
     }))
@@ -2557,7 +2572,15 @@ fn push_action(
     locator: PrerunPageActionLocator,
     out: &mut Vec<PrerunPageActionEvent>,
 ) -> Result<()> {
-    validate_entry_node(board, page_id, "action", node_id)?;
+    // A Page may reference a node that was since edited out of its board. Only
+    // that action becomes non-executable — absent from the contract it can
+    // never be decorated, sealed, or redeemed — while the Page keeps loading.
+    // Failing the whole extraction would brick every surface of the Page until
+    // someone repairs the stale reference.
+    if let Err(error) = validate_entry_node(board, page_id, "action", node_id) {
+        tracing::warn!(%error, "Skipping non-executable Page action during extraction");
+        return Ok(());
+    }
     out.push(PrerunPageActionEvent {
         action_id: page_action_id(page_id, node_id, &locator),
         node_id: node_id.to_string(),
@@ -4479,7 +4502,10 @@ mod tests {
     }
 
     #[test]
-    fn rejects_non_entry_targets_and_duplicate_widget_instances() {
+    fn stale_targets_are_dropped_but_structural_damage_still_rejects() {
+        // A target that is no longer an entry node (or no longer exists at
+        // all) disables that one action; the Page must keep extracting so it
+        // can still load and render its remaining, valid actions.
         let mut board = page_board();
         let mut internal = Node::new("noop", "Internal", "", "Other");
         internal.id = "internal".into();
@@ -4487,10 +4513,34 @@ mod tests {
         let mut page = configured_page();
         page.components[0].component["eventHandlers"]["click"][1]["context"]["nodeId"] =
             json!("internal");
-        let error = extract_page_execution(&board, &page)
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains("not an entry node"), "{error}");
+        let execution = extract_page_execution(&board, &page).unwrap();
+        assert!(
+            execution
+                .action_events
+                .iter()
+                .all(|action| action.node_id != "internal"),
+            "a non-entry target must be dropped, not extracted"
+        );
+        assert!(
+            !execution.action_events.is_empty(),
+            "valid actions must survive a sibling's stale target"
+        );
+
+        let mut missing = configured_page();
+        missing.components[0].component["eventHandlers"]["click"][1]["context"]["nodeId"] =
+            json!("deleted-node");
+        missing.on_load_event_id = Some("deleted-node".into());
+        let execution = extract_page_execution(&board, &missing).unwrap();
+        assert!(
+            execution
+                .action_events
+                .iter()
+                .all(|action| action.node_id != "deleted-node"),
+        );
+        assert!(
+            execution.special_events.load.is_none(),
+            "a lifecycle hook with a deleted target must be disabled"
+        );
 
         let mut duplicate = configured_page();
         duplicate.components.push(SurfaceComponent::new(

--- a/packages/core/src/flow/event.rs
+++ b/packages/core/src/flow/event.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, time::SystemTime};
 
-use flow_like_storage::Path;
+use flow_like_storage::{Path, object_store};
 use flow_like_types::{FromProto, ToProto, create_id, proto};
 use futures::{StreamExt, TryStreamExt};
 use schemars::JsonSchema;
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     app::App,
     state::FlowLikeState,
-    utils::compression::{compress_to_file, from_compressed},
+    utils::compression::{compress_to_file, compress_to_file_create, from_compressed},
 };
 
 use super::{
@@ -253,6 +253,20 @@ pub enum EventPayload {
     QuickAction,
 }
 
+/// Whether a failed [`Event::load`] means the object is genuinely absent, as
+/// opposed to unreadable (transient store error, truncated/corrupt bytes).
+/// Only absence may fall through to the create branch of [`Event::upsert`] —
+/// anything else must abort the write, or one flaky read forks the event into
+/// a duplicate under a fresh id.
+fn load_error_is_not_found(error: &flow_like_types::Error) -> bool {
+    error.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<object_store::Error>(),
+            Some(object_store::Error::NotFound { .. })
+        )
+    })
+}
+
 pub fn canary_equal(a: &Option<CanaryEvent>, b: &Option<CanaryEvent>) -> bool {
     match (a, b) {
         (Some(a), Some(b)) => {
@@ -343,8 +357,17 @@ impl Event {
             tracing::warn!("Failed to populate event inputs during upsert: {}", e);
         }
 
-        let old_event = Event::load(&self.id, app, None).await;
-        if let Ok(mut old_event) = old_event {
+        let old_event = match Event::load(&self.id, app, None).await {
+            Ok(event) => Some(event),
+            Err(error) if load_error_is_not_found(&error) => None,
+            Err(error) => {
+                return Err(error.context(format!(
+                    "loading existing event {} failed during upsert; refusing to recreate it under a fresh id",
+                    self.id
+                )));
+            }
+        };
+        if let Some(mut old_event) = old_event {
             if old_event.node_id != self.node_id
                 || old_event.board_id != self.board_id
                 || !canary_equal(&old_event.canary, &self.canary)
@@ -600,15 +623,41 @@ impl Event {
             .await?
             .as_generic();
 
-        let event_path = match version {
-            Some(version) => storage_root
-                .child("versions")
-                .child(self.id.clone())
-                .child(format!("{}.{}.{}", version.0, version.1, version.2)),
-            None => storage_root.child(format!("{}.event", self.id)),
+        let proto = self.to_proto();
+        let Some(version) = version else {
+            let event_path = storage_root.child(format!("{}.event", self.id));
+            compress_to_file(store, event_path, &proto).await?;
+            return Ok(());
         };
 
-        compress_to_file(store, event_path, &self.to_proto()).await?;
+        // Archived versions are immutable, like board snapshots: a create-only
+        // write means two racing publishers cannot destroy each other's slot.
+        // An identical occupant is success — it is also the crash-recovery path
+        // where an earlier upsert archived this version but died before writing
+        // the live object; without it the event would wedge unsaveable.
+        let event_path = storage_root
+            .child("versions")
+            .child(self.id.clone())
+            .child(format!("{}.{}.{}", version.0, version.1, version.2));
+        if let Err(create_error) =
+            compress_to_file_create(store.clone(), event_path.clone(), &proto).await
+        {
+            let existing: flow_like_types::Result<proto::Event> =
+                from_compressed(store, event_path).await;
+            match existing {
+                Ok(existing) if existing == proto => {}
+                Ok(_) => {
+                    return Err(flow_like_types::anyhow!(
+                        "archived version {}.{}.{} of event {} already exists with different content; refusing to overwrite it",
+                        version.0,
+                        version.1,
+                        version.2,
+                        self.id
+                    ));
+                }
+                Err(_) => return Err(create_error),
+            }
+        }
         Ok(())
     }
 
@@ -650,8 +699,143 @@ impl Event {
 
 #[cfg(test)]
 mod tests {
-    use super::{ChatEventParameters, EventPayload};
+    use super::{ChatEventParameters, Event, EventPayload, load_error_is_not_found};
+    use crate::state::{FlowLikeConfig, FlowLikeState};
+    use flow_like_storage::{
+        Path,
+        files::store::FlowLikeStore,
+        object_store::{self, PutPayload},
+    };
+    use flow_like_types::tokio;
     use serde_json::json;
+    use std::{collections::HashMap, sync::Arc, time::SystemTime};
+
+    async fn test_app() -> crate::app::App {
+        let mut config = FlowLikeConfig::new();
+        config.register_app_meta_store(FlowLikeStore::Other(Arc::new(
+            object_store::memory::InMemory::new(),
+        )));
+        config.register_app_storage_store(FlowLikeStore::Other(Arc::new(
+            object_store::memory::InMemory::new(),
+        )));
+        let state = Arc::new(FlowLikeState::new(
+            config,
+            crate::utils::http::HTTPClient::new_without_refetch(),
+        ));
+        crate::app::App::new(None, crate::bit::Metadata::default(), vec![], state)
+            .await
+            .unwrap()
+    }
+
+    fn storage_event(id: &str) -> Event {
+        Event {
+            id: id.to_string(),
+            name: "Storage Fixture".to_string(),
+            description: String::new(),
+            board_id: String::new(),
+            board_version: None,
+            node_id: String::new(),
+            variables: HashMap::new(),
+            config: Vec::new(),
+            active: false,
+            canary: None,
+            priority: 0,
+            event_type: "quick_action".to_string(),
+            notes: None,
+            event_version: (0, 0, 0),
+            created_at: SystemTime::UNIX_EPOCH,
+            updated_at: SystemTime::UNIX_EPOCH,
+            default_page_id: None,
+            inputs: Vec::new(),
+            route: None,
+            is_default: false,
+            execution_mode: super::EventExecutionMode::Local,
+            exposure: super::EventExposure::Public,
+            correlation_mappings: None,
+        }
+    }
+
+    #[test]
+    fn load_error_classification_only_treats_missing_objects_as_absent() {
+        let not_found: flow_like_types::Error = object_store::Error::NotFound {
+            path: "apps/a/events/e.event".to_string(),
+            source: "gone".into(),
+        }
+        .into();
+        assert!(load_error_is_not_found(&not_found));
+        assert!(load_error_is_not_found(
+            &not_found.context("loading event failed")
+        ));
+
+        assert!(!load_error_is_not_found(&flow_like_types::anyhow!(
+            "connection reset"
+        )));
+        let other_store_error: flow_like_types::Error = object_store::Error::Generic {
+            store: "s3",
+            source: "throttled".into(),
+        }
+        .into();
+        assert!(!load_error_is_not_found(&other_store_error));
+    }
+
+    #[tokio::test]
+    async fn archived_event_versions_are_immutable() {
+        let app = test_app().await;
+        let event = storage_event("evt-immutable");
+
+        event.save(&app, Some((1, 0, 0))).await.unwrap();
+        // The identical occupant is the crash-recovery path: archiving again
+        // after a died live-write must not wedge the event.
+        event.save(&app, Some((1, 0, 0))).await.unwrap();
+
+        let mut changed = event.clone();
+        changed.name = "Different Content".to_string();
+        let error = changed.save(&app, Some((1, 0, 0))).await.unwrap_err();
+        assert!(
+            error.to_string().contains("refusing to overwrite"),
+            "unexpected error: {error:#}"
+        );
+
+        // The live object stays last-write-wins.
+        changed.save(&app, None).await.unwrap();
+        event.save(&app, None).await.unwrap();
+        let live = Event::load(&event.id, &app, None).await.unwrap();
+        assert_eq!(live.name, event.name);
+    }
+
+    #[tokio::test]
+    async fn upsert_creates_on_absence_but_refuses_unreadable_events() {
+        let app = test_app().await;
+
+        let mut fresh = storage_event("evt-upsert");
+        let created = fresh.upsert(&app, None, true).await.unwrap();
+        assert_eq!(created.id, "evt-upsert");
+        assert_eq!(created.event_version, (0, 0, 0));
+
+        // Corrupt the live object: the next upsert must surface the read
+        // failure instead of forking the event under a fresh id.
+        let store = FlowLikeState::project_meta_store(app.app_state.as_ref().unwrap())
+            .await
+            .unwrap()
+            .as_generic();
+        let live_path = Path::from("apps")
+            .child(app.id.clone())
+            .child("events")
+            .child("evt-upsert.event");
+        store
+            .put(&live_path, PutPayload::from_static(b"not lz4 protobuf"))
+            .await
+            .unwrap();
+
+        let mut update = storage_event("evt-upsert");
+        update.name = "Update Attempt".to_string();
+        let error = update.upsert(&app, None, true).await.unwrap_err();
+        assert!(
+            format!("{error:#}").contains("refusing to recreate"),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(update.id, "evt-upsert");
+    }
 
     #[test]
     fn chat_event_parameters_default_presentation_fields_to_none() {


### PR DESCRIPTION
This pull request introduces two main improvements: it refines AWS credential policy generation to correctly handle S3 Express directory buckets and improves the resilience of page extraction and event upserts in the core flow logic. The AWS policy logic now ensures that per-object IAM statements are omitted for S3 Express buckets to avoid exceeding policy size limits, and new tests verify this behavior. In the core flow, page extraction and event upserts are made more tolerant of stale or missing targets, logging warnings and skipping only the affected actions or hooks instead of failing the entire process.

**AWS Credentials Policy Handling:**

* Introduced the `meta_bucket_express_zone()` function to cache and determine if the meta bucket is an S3 Express directory bucket, ensuring policy statements are mutually exclusive and avoiding policy size overflows.
* Refactored `server_execute_policy()` to emit only the necessary IAM statements for either standard or express buckets, with new logic to generate a minimal policy for S3 Express and comprehensive tests to ensure policy size stays within AWS limits. [[1]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959R528-L523) [[2]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959L586-R623) [[3]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959L603-R653) [[4]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959R1306) [[5]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959L1335-R1365) [[6]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959R1388-R1428) [[7]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959R1459)

**Core Flow Robustness:**

* Updated `extract_page_execution`, `optional_special_target`, and `push_action` in `prerun.rs` to gracefully skip and warn about missing or non-executable nodes, allowing the rest of the page to load and function. [[1]](diffhunk://#diff-ea1d6dec432cd1054669aec30bd177cd10899bce42133b97083c02fcfec08287L1025-R1049) [[2]](diffhunk://#diff-ea1d6dec432cd1054669aec30bd177cd10899bce42133b97083c02fcfec08287L1875-R1890) [[3]](diffhunk://#diff-ea1d6dec432cd1054669aec30bd177cd10899bce42133b97083c02fcfec08287L2560-R2583)
* Added and updated tests to ensure stale or missing targets only affect the relevant actions or hooks, not the entire page extraction.

**Event Upsert Resilience:**

* Added `load_error_is_not_found()` to distinguish between genuinely absent and unreadable events, ensuring that only true absences allow for event recreation and preventing accidental duplication on transient errors. [[1]](diffhunk://#diff-960b8ba9f5607c53b9925e12d7983f2ea0fa5f505ef06db57de290b6b9a8b928R256-R269) [[2]](diffhunk://#diff-960b8ba9f5607c53b9925e12d7983f2ea0fa5f505ef06db57de290b6b9a8b928L346-R370)
* Updated imports to support new object store error handling and compression utilities. [[1]](diffhunk://#diff-960b8ba9f5607c53b9925e12d7983f2ea0fa5f505ef06db57de290b6b9a8b928L3-R3) [[2]](diffhunk://#diff-960b8ba9f5607c53b9925e12d7983f2ea0fa5f505ef06db57de290b6b9a8b928L12-R12)