### PR TITLE
Refactor entity definitions for consistency and enhance features

### DIFF
--- a/.github/scripts/ort-glibc-compat.c
+++ b/.github/scripts/ort-glibc-compat.c
@@ -1,0 +1,72 @@
+/*
+ * Compatibility shim for the prebuilt ONNX Runtime archive on the Linux release
+ * baseline.
+ *
+ * `ort` downloads a static ONNX Runtime from pyke's CDN. Those archives are
+ * compiled on a host with glibc >= 2.38 and libstdc++ >= 13, which redirects the
+ * string-to-integer functions to their C23 variants and emits
+ * __cxa_call_terminate on cleanup paths that may throw. Neither exists on the
+ * Ubuntu 22.04 / glibc 2.35 baseline the Linux artifacts are built against, so
+ * the desktop binary fails to link with undefined references. Building on a
+ * newer runner is not an alternative: it would stamp GLIBC_2.38 into the
+ * shipped binary and lose every distribution below it.
+ *
+ * The C23 functions differ from the C17 ones only in accepting a 0b prefix for
+ * base 0 and base 2, which ONNX Runtime never parses, so forwarding is exact for
+ * every input it produces.
+ *
+ * prepare-ort-glibc-compat.sh compiles this and only links it when the build
+ * toolchain does not already provide these symbols. Delete both files once the
+ * Linux baseline reaches glibc 2.38 and GCC 13.
+ */
+
+#define _GNU_SOURCE
+
+#include <locale.h>
+#include <stdlib.h>
+
+long __isoc23_strtol(const char *nptr, char **endptr, int base) {
+	return strtol(nptr, endptr, base);
+}
+
+unsigned long __isoc23_strtoul(const char *nptr, char **endptr, int base) {
+	return strtoul(nptr, endptr, base);
+}
+
+long long __isoc23_strtoll(const char *nptr, char **endptr, int base) {
+	return strtoll(nptr, endptr, base);
+}
+
+unsigned long long __isoc23_strtoull(const char *nptr, char **endptr, int base) {
+	return strtoull(nptr, endptr, base);
+}
+
+long long __isoc23_strtoll_l(const char *nptr, char **endptr, int base, locale_t loc) {
+	return strtoll_l(nptr, endptr, base, loc);
+}
+
+unsigned long long __isoc23_strtoull_l(const char *nptr, char **endptr, int base, locale_t loc) {
+	return strtoull_l(nptr, endptr, base, loc);
+}
+
+/*
+ * std::terminate() and __cxa_begin_catch live in libstdc++. RUSTFLAGS applies to
+ * build script executables too, and those do not link libstdc++, so both
+ * references are weak and the shim degrades to abort() when they are absent.
+ * _ZSt9terminatev is the Itanium ABI mangling of std::terminate(), spelled out
+ * so this stays a C translation unit.
+ */
+extern void _ZSt9terminatev(void) __attribute__((weak));
+extern void *__cxa_begin_catch(void *unwind_exception) __attribute__((weak));
+
+__attribute__((noreturn)) void __cxa_call_terminate(void *unwind_exception) {
+	if (unwind_exception != NULL && __cxa_begin_catch != NULL) {
+		__cxa_begin_catch(unwind_exception);
+	}
+
+	if (_ZSt9terminatev != NULL) {
+		_ZSt9terminatev();
+	}
+
+	abort();
+}

--- a/.github/scripts/prepare-ort-glibc-compat.sh
+++ b/.github/scripts/prepare-ort-glibc-compat.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Links ort-glibc-compat.c into the Linux build when the toolchain is older than
+# the one pyke used to build the prebuilt ONNX Runtime archive. See that file for
+# why the shim exists.
+#
+# The object is appended to RUSTFLAGS rather than emitted from a build script so
+# nothing in the shipped sources depends on it. An object file is fully included
+# wherever it appears on the linker command line, so its position among the
+# archives does not matter.
+
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "Not a Linux build host; the ONNX Runtime compatibility shim is not needed."
+  exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source_file="$script_dir/ort-glibc-compat.c"
+object_file="${ORT_GLIBC_COMPAT_OBJECT:-${RUNNER_TEMP:-/tmp}/ort-glibc-compat.o}"
+compiler="${CC:-cc}"
+
+symbols=(
+  __isoc23_strtol
+  __isoc23_strtoul
+  __isoc23_strtoll
+  __isoc23_strtoull
+  __isoc23_strtoll_l
+  __isoc23_strtoull_l
+  __cxa_call_terminate
+)
+
+probe_dir="$(mktemp -d)"
+trap 'rm -rf "$probe_dir"' EXIT
+
+# Declared with a dummy signature: this only has to reach the linker.
+{
+  for symbol in "${symbols[@]}"; do
+    printf 'extern void %s(void);\n' "$symbol"
+  done
+  printf 'int main(void) {\n'
+  for symbol in "${symbols[@]}"; do
+    printf '\t%s();\n' "$symbol"
+  done
+  printf '\treturn 0;\n}\n'
+} > "$probe_dir/probe.c"
+
+if "$compiler" -o "$probe_dir/probe" "$probe_dir/probe.c" -lstdc++ > "$probe_dir/probe.log" 2>&1; then
+  echo "The build toolchain already provides every symbol the ONNX Runtime archive references; skipping the compatibility shim."
+  exit 0
+fi
+
+echo "The build toolchain is missing symbols the ONNX Runtime archive references:"
+grep -o "undefined reference to \`[^']*'" "$probe_dir/probe.log" |
+  sed -e "s/undefined reference to .//" -e "s/'\$//" |
+  sort -u |
+  sed 's/^/  /'
+
+if ! "$compiler" -c -O2 -fPIC -o "$object_file" "$source_file"; then
+  echo "::error::Failed to compile the ONNX Runtime compatibility shim from $source_file."
+  exit 1
+fi
+
+for symbol in "${symbols[@]}"; do
+  if ! nm --defined-only "$object_file" | grep -q " $symbol\$"; then
+    echo "::error::The compiled shim does not define $symbol."
+    exit 1
+  fi
+done
+
+echo "Compiled the ONNX Runtime compatibility shim to $object_file."
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+  printf 'RUSTFLAGS=%s\n' "${RUSTFLAGS:+$RUSTFLAGS }-Clink-arg=$object_file" >> "$GITHUB_ENV"
+  echo "Appended -Clink-arg=$object_file to RUSTFLAGS."
+fi

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -249,6 +249,13 @@ jobs:
         shell: bash
         run: .github/scripts/ensure-spa-headers.sh
 
+      # Runs before the Rust cache so the RUSTFLAGS it exports are part of the
+      # cache key.
+      - name: Prepare ONNX Runtime glibc shim (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: bash .github/scripts/prepare-ort-glibc-compat.sh
+
       - name: Configure bounded macOS codesign retries
         if: runner.os == 'macOS'
         shell: bash

--- a/packages/api/src/credentials/aws_credentials.rs
+++ b/packages/api/src/credentials/aws_credentials.rs
@@ -230,6 +230,7 @@ impl AwsRuntimeCredentials {
                 &runs_prefix,
                 &temporary_user_prefix,
                 &temporary_global_prefix,
+                meta_bucket_express_zone(),
             ),
             CredentialsAccess::ReadLogs => read_logs_policy(self, &runs_prefix),
         };
@@ -303,13 +304,27 @@ fn scoped_content_path_prefixes(
     (app, user)
 }
 
+/// Whether the meta bucket is an S3 Express directory bucket. On a directory
+/// bucket the CreateSession token — not per-object IAM — authorizes every
+/// zonal request, so the two bucket flavors need disjoint policy statements.
+/// Emitting both flavors in one session policy pushed AssumeRole past its
+/// packed-policy budget (PackedPolicyTooLargeException at dispatch).
+/// Deployment configuration never changes within a process, so the env var is
+/// read once.
+fn meta_bucket_express_zone() -> bool {
+    static META_BUCKET_EXPRESS_ZONE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *META_BUCKET_EXPRESS_ZONE.get_or_init(|| {
+        std::env::var("META_BUCKET_EXPRESS_ZONE")
+            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+            .unwrap_or(false)
+    })
+}
+
 #[cfg(feature = "aws")]
 #[async_trait]
 impl RuntimeCredentialsTrait for AwsRuntimeCredentials {
     fn into_shared_credentials(&self) -> SharedCredentials {
-        let meta_express = std::env::var("META_BUCKET_EXPRESS_ZONE")
-            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
-            .unwrap_or(false);
+        let meta_express = meta_bucket_express_zone();
         let content_express = std::env::var("CONTENT_BUCKET_EXPRESS_ZONE")
             .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
             .unwrap_or(false);
@@ -510,6 +525,7 @@ fn server_execute_policy(
     runs_prefix: &str,
     temporary_user_prefix: &str,
     temporary_global_prefix: &str,
+    meta_express: bool,
 ) -> flow_like_types::Value {
     // Draft artifacts (compiled boards, exact `.board` snapshots, prerun
     // manifests) live under `tmp/apps/{app_id}/` on the meta bucket so
@@ -517,121 +533,124 @@ fn server_execute_policy(
     // read-only grant there as on `apps/{app_id}` — only the API writes
     // drafts, which anchors `entry_authority_revision`.
     let draft_meta_prefix = format!("tmp/{apps_prefix}");
+    let mut statements = vec![
+        json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3:ListBucket"
+          ],
+          "Resource": [
+              format!("arn:aws:s3:::{}", credentials.content_bucket)
+          ],
+          "Condition": {
+              "StringLike": {
+                  "s3:prefix": [
+                      format!("{}/*", apps_prefix),
+                      format!("{}/*", user_prefix),
+                      format!("{}/*", temporary_user_prefix),
+                      format!("{}/*", temporary_global_prefix)
+                  ]
+              }
+          }
+        }),
+        json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3:GetObject",
+              "s3:PutObject",
+              "s3:DeleteObject"
+          ],
+          "Resource": [
+              format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, apps_prefix),
+              format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, user_prefix),
+              format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, temporary_user_prefix),
+              format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, temporary_global_prefix),
+          ],
+        }),
+        json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3:ListBucket"
+          ],
+          "Resource": [
+              format!("arn:aws:s3:::{}", credentials.logs_bucket)
+          ],
+          "Condition": {
+              "StringLike": {
+                  "s3:prefix": [
+                      format!("{}/*", runs_prefix)
+                  ]
+              }
+          }
+        }),
+        // Run logs are append-only: the executor creates and appends Lance
+        // tables (fresh data files, `.txn` files, conditional-put manifests)
+        // and never deletes; Lance's auto-cleanup is best-effort and logs on
+        // denial. Without DeleteObject a compromised run cannot erase or
+        // rewrite another run's audit trail.
+        json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3:GetObject",
+              "s3:PutObject"
+          ],
+          "Resource": [
+              format!("arn:aws:s3:::{}/{}/*", credentials.logs_bucket, runs_prefix),
+          ],
+        }),
+    ];
+    if meta_express {
+        // On a directory bucket the session token — not per-object IAM —
+        // authorizes every zonal request, so the `s3:*` meta statements would
+        // never be evaluated; emitting them anyway blew the AssumeRole packed
+        // policy budget. Pin the session to ReadOnly so this mode cannot
+        // write the meta bucket.
+        statements.push(json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3express:CreateSession",
+          ],
+          "Resource": [
+              "*"
+          ],
+          "Condition": {
+              "StringEquals": {
+                  "s3express:SessionMode": "ReadOnly"
+              }
+          }
+        }));
+    } else {
+        statements.push(json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3:ListBucket"
+          ],
+          "Resource": [
+              format!("arn:aws:s3:::{}", credentials.meta_bucket)
+          ],
+          "Condition": {
+              "StringLike": {
+                  "s3:prefix": [
+                      format!("{}/*", apps_prefix),
+                      format!("{}/*", draft_meta_prefix)
+                  ]
+              }
+          }
+        }));
+        statements.push(json!({
+          "Effect": "Allow",
+          "Action": [
+              "s3:GetObject"
+          ],
+          "Resource": [
+              format!("arn:aws:s3:::{}/{}/*", credentials.meta_bucket, apps_prefix),
+              format!("arn:aws:s3:::{}/{}/*", credentials.meta_bucket, draft_meta_prefix),
+          ],
+        }));
+    }
     json!({
         "Version": "2012-10-17",
-        "Statement": [
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                format!("arn:aws:s3:::{}", credentials.content_bucket)
-            ],
-            "Condition": {
-                "StringLike": {
-                    "s3:prefix": [
-                        format!("{}/*", apps_prefix),
-                        format!("{}/*", user_prefix),
-                        format!("{}/*", temporary_user_prefix),
-                        format!("{}/*", temporary_global_prefix)
-                    ]
-                }
-            }
-          },
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:DeleteObject"
-            ],
-            "Resource": [
-                format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, apps_prefix),
-                format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, user_prefix),
-                format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, temporary_user_prefix),
-                format!("arn:aws:s3:::{}/{}/*", credentials.content_bucket, temporary_global_prefix),
-            ],
-          },
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                format!("arn:aws:s3:::{}", credentials.logs_bucket)
-            ],
-            "Condition": {
-                "StringLike": {
-                    "s3:prefix": [
-                        format!("{}/*", runs_prefix)
-                    ]
-                }
-            }
-          },
-          // Run logs are append-only: the executor creates and appends Lance
-          // tables (fresh data files, `.txn` files, conditional-put manifests)
-          // and never deletes; Lance's auto-cleanup is best-effort and logs on
-          // denial. Without DeleteObject a compromised run cannot erase or
-          // rewrite another run's audit trail.
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject"
-            ],
-            "Resource": [
-                format!("arn:aws:s3:::{}/{}/*", credentials.logs_bucket, runs_prefix),
-            ],
-          },
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                format!("arn:aws:s3:::{}", credentials.meta_bucket)
-            ],
-            "Condition": {
-                "StringLike": {
-                    "s3:prefix": [
-                        format!("{}/*", apps_prefix),
-                        format!("{}/*", draft_meta_prefix)
-                    ]
-                }
-            }
-          },
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject"
-            ],
-            "Resource": [
-                format!("arn:aws:s3:::{}/{}/*", credentials.meta_bucket, apps_prefix),
-                format!("arn:aws:s3:::{}/{}/*", credentials.meta_bucket, draft_meta_prefix),
-                format!("arn:aws:s3express:::{}/{}/*", credentials.meta_bucket, apps_prefix),
-                format!("arn:aws:s3express:::{}/{}/*", credentials.meta_bucket, draft_meta_prefix),
-            ],
-          },
-          {
-            "Effect": "Allow",
-            "Action": [
-                "s3express:CreateSession",
-            ],
-            "Resource": [
-                "*"
-            ],
-            // On a directory bucket the session token — not per-object IAM —
-            // authorizes every zonal request, and object_store asks for the
-            // maximum privilege. Pin the session to ReadOnly so this mode
-            // cannot write to the meta bucket.
-            "Condition": {
-                "StringEquals": {
-                    "s3express:SessionMode": "ReadOnly"
-                }
-            }
-          }
-        ],
+        "Statement": statements,
     })
 }
 
@@ -1284,6 +1303,7 @@ mod tests {
             "runs/app-1",
             "tmp/user/user-1/apps/app-1",
             "tmp/global/apps/app-1",
+            false,
         );
         let statements = policy["Statement"]
             .as_array()
@@ -1332,13 +1352,16 @@ mod tests {
         assert!(draft_artifact.starts_with("tmp/apps/app-1/"));
         assert!(!other_app_artifact.starts_with("tmp/apps/app-1/"));
         assert!(
-            meta_resources.contains("meta-secret/tmp/apps/app-1/*")
-                && meta_resources.contains("s3express:::meta-secret/tmp/apps/app-1/*"),
+            meta_resources.contains("meta-secret/tmp/apps/app-1/*"),
             "draft artifacts under tmp/apps must stay readable: {meta_resources}"
         );
         assert!(
             meta_list_prefixes.contains("tmp/apps/app-1/*"),
             "draft artifacts under tmp/apps must stay listable: {meta_list_prefixes}"
+        );
+        assert!(
+            !policy.to_string().contains("s3express"),
+            "a standard meta bucket needs no express statements"
         );
         assert!(policy.contains("content-data/apps/app-1/*"));
         assert!(policy.contains("logs/runs/app-1/*"));
@@ -1359,6 +1382,47 @@ mod tests {
         assert!(
             !meta_actions.contains("DeleteObject"),
             "ServerExecute must not grant meta deletes"
+        );
+    }
+
+    /// On an express meta bucket the CreateSession token authorizes every
+    /// zonal request, so the per-object meta statements are dead weight — and
+    /// carrying both flavors once pushed AssumeRole past its packed-policy
+    /// budget in production (PackedPolicyTooLargeException at dispatch).
+    #[test]
+    fn test_aws_server_execute_express_variant_stays_within_policy_budget() {
+        let creds = test_aws_runtime_credentials();
+        // Realistic id lengths: generated app ids and IdP subjects are long,
+        // and every prefix repeats them several times.
+        let app = "apps/v8f5p73w00itor03zlrai22w";
+        let user = "users/auth0|64c9f0aa11bb22cc33dd44ee/apps/v8f5p73w00itor03zlrai22w";
+        let runs = "runs/v8f5p73w00itor03zlrai22w";
+        let tmp_user = "tmp/user/auth0|64c9f0aa11bb22cc33dd44ee/apps/v8f5p73w00itor03zlrai22w";
+        let tmp_global = "tmp/global/apps/v8f5p73w00itor03zlrai22w";
+
+        let express = server_execute_policy(&creds, app, user, runs, tmp_user, tmp_global, true);
+        let express_json = to_string(&express).expect("policy should serialize");
+        assert!(
+            !express_json.contains("arn:aws:s3:::meta-secret"),
+            "express meta access flows through CreateSession, not per-object IAM"
+        );
+        assert!(express_json.contains("s3express:CreateSession"));
+        assert!(express_json.contains("ReadOnly"));
+
+        let standard = server_execute_policy(&creds, app, user, runs, tmp_user, tmp_global, false);
+        let standard_json = to_string(&standard).expect("policy should serialize");
+
+        // STS caps the plaintext at 2048 characters and packs it into a
+        // shared binary quota; both variants must keep real headroom.
+        assert!(
+            express_json.len() < 1600,
+            "express ServerExecute policy grew to {} chars",
+            express_json.len()
+        );
+        assert!(
+            standard_json.len() < 1900,
+            "standard ServerExecute policy grew to {} chars",
+            standard_json.len()
         );
     }
 
@@ -1392,6 +1456,7 @@ mod tests {
                 "runs/app-1",
                 "tmp/user/user-1/apps/app-1",
                 "tmp/global/apps/app-1",
+                true,
             ))
             .as_deref(),
             Some("\"ReadOnly\""),

--- a/packages/core/src/flow/compiled/prerun.rs
+++ b/packages/core/src/flow/compiled/prerun.rs
@@ -1022,21 +1022,31 @@ pub fn extract_page_execution(board: &Board, page: &Page) -> Result<PrerunPageEx
         optional_special_target(board, page, "unload", page.on_unload_event_id.as_deref())?;
     let interval = match page.on_interval_event_id.as_deref() {
         Some(node_id) if !node_id.is_empty() => {
-            validate_entry_node(board, &page.id, "special interval", node_id)?;
-            let seconds = page
-                .on_interval_seconds
-                .filter(|seconds| *seconds > 0)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "page '{}' configures interval node '{}' without a positive interval",
-                        page.id,
-                        node_id
-                    )
-                })?;
-            Some(PrerunPageIntervalEvent {
-                node_id: node_id.to_string(),
-                interval_seconds: Some(seconds),
-            })
+            // Tolerant like the other hooks: a stale target or broken period
+            // disables the interval instead of making the Page unloadable.
+            match validate_entry_node(board, &page.id, "special interval", node_id) {
+                Err(error) => {
+                    tracing::warn!(
+                        %error,
+                        "Skipping non-executable Page interval hook during extraction"
+                    );
+                    None
+                }
+                Ok(()) => match page.on_interval_seconds.filter(|seconds| *seconds > 0) {
+                    Some(seconds) => Some(PrerunPageIntervalEvent {
+                        node_id: node_id.to_string(),
+                        interval_seconds: Some(seconds),
+                    }),
+                    None => {
+                        tracing::warn!(
+                            page_id = %page.id,
+                            node_id,
+                            "Skipping Page interval hook without a positive period"
+                        );
+                        None
+                    }
+                },
+            }
         }
         _ => None,
     };
@@ -1872,7 +1882,12 @@ fn optional_special_target(
     let Some(node_id) = node_id.filter(|node_id| !node_id.is_empty()) else {
         return Ok(None);
     };
-    validate_entry_node(board, &page.id, &format!("special {kind}"), node_id)?;
+    // Same tolerance as `push_action`: a hook whose target left the board is
+    // disabled rather than making the Page unloadable.
+    if let Err(error) = validate_entry_node(board, &page.id, &format!("special {kind}"), node_id) {
+        tracing::warn!(%error, "Skipping non-executable Page lifecycle hook during extraction");
+        return Ok(None);
+    }
     Ok(Some(PrerunPageEventTarget {
         node_id: node_id.to_string(),
     }))
@@ -2557,7 +2572,15 @@ fn push_action(
     locator: PrerunPageActionLocator,
     out: &mut Vec<PrerunPageActionEvent>,
 ) -> Result<()> {
-    validate_entry_node(board, page_id, "action", node_id)?;
+    // A Page may reference a node that was since edited out of its board. Only
+    // that action becomes non-executable — absent from the contract it can
+    // never be decorated, sealed, or redeemed — while the Page keeps loading.
+    // Failing the whole extraction would brick every surface of the Page until
+    // someone repairs the stale reference.
+    if let Err(error) = validate_entry_node(board, page_id, "action", node_id) {
+        tracing::warn!(%error, "Skipping non-executable Page action during extraction");
+        return Ok(());
+    }
     out.push(PrerunPageActionEvent {
         action_id: page_action_id(page_id, node_id, &locator),
         node_id: node_id.to_string(),
@@ -4479,7 +4502,10 @@ mod tests {
     }
 
     #[test]
-    fn rejects_non_entry_targets_and_duplicate_widget_instances() {
+    fn stale_targets_are_dropped_but_structural_damage_still_rejects() {
+        // A target that is no longer an entry node (or no longer exists at
+        // all) disables that one action; the Page must keep extracting so it
+        // can still load and render its remaining, valid actions.
         let mut board = page_board();
         let mut internal = Node::new("noop", "Internal", "", "Other");
         internal.id = "internal".into();
@@ -4487,10 +4513,34 @@ mod tests {
         let mut page = configured_page();
         page.components[0].component["eventHandlers"]["click"][1]["context"]["nodeId"] =
             json!("internal");
-        let error = extract_page_execution(&board, &page)
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains("not an entry node"), "{error}");
+        let execution = extract_page_execution(&board, &page).unwrap();
+        assert!(
+            execution
+                .action_events
+                .iter()
+                .all(|action| action.node_id != "internal"),
+            "a non-entry target must be dropped, not extracted"
+        );
+        assert!(
+            !execution.action_events.is_empty(),
+            "valid actions must survive a sibling's stale target"
+        );
+
+        let mut missing = configured_page();
+        missing.components[0].component["eventHandlers"]["click"][1]["context"]["nodeId"] =
+            json!("deleted-node");
+        missing.on_load_event_id = Some("deleted-node".into());
+        let execution = extract_page_execution(&board, &missing).unwrap();
+        assert!(
+            execution
+                .action_events
+                .iter()
+                .all(|action| action.node_id != "deleted-node"),
+        );
+        assert!(
+            execution.special_events.load.is_none(),
+            "a lifecycle hook with a deleted target must be disabled"
+        );
 
         let mut duplicate = configured_page();
         duplicate.components.push(SurfaceComponent::new(

--- a/packages/core/src/flow/event.rs
+++ b/packages/core/src/flow/event.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, time::SystemTime};
 
-use flow_like_storage::Path;
+use flow_like_storage::{Path, object_store};
 use flow_like_types::{FromProto, ToProto, create_id, proto};
 use futures::{StreamExt, TryStreamExt};
 use schemars::JsonSchema;
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     app::App,
     state::FlowLikeState,
-    utils::compression::{compress_to_file, from_compressed},
+    utils::compression::{compress_to_file, compress_to_file_create, from_compressed},
 };
 
 use super::{
@@ -253,6 +253,20 @@ pub enum EventPayload {
     QuickAction,
 }
 
+/// Whether a failed [`Event::load`] means the object is genuinely absent, as
+/// opposed to unreadable (transient store error, truncated/corrupt bytes).
+/// Only absence may fall through to the create branch of [`Event::upsert`] —
+/// anything else must abort the write, or one flaky read forks the event into
+/// a duplicate under a fresh id.
+fn load_error_is_not_found(error: &flow_like_types::Error) -> bool {
+    error.chain().any(|cause| {
+        matches!(
+            cause.downcast_ref::<object_store::Error>(),
+            Some(object_store::Error::NotFound { .. })
+        )
+    })
+}
+
 pub fn canary_equal(a: &Option<CanaryEvent>, b: &Option<CanaryEvent>) -> bool {
     match (a, b) {
         (Some(a), Some(b)) => {
@@ -343,8 +357,17 @@ impl Event {
             tracing::warn!("Failed to populate event inputs during upsert: {}", e);
         }
 
-        let old_event = Event::load(&self.id, app, None).await;
-        if let Ok(mut old_event) = old_event {
+        let old_event = match Event::load(&self.id, app, None).await {
+            Ok(event) => Some(event),
+            Err(error) if load_error_is_not_found(&error) => None,
+            Err(error) => {
+                return Err(error.context(format!(
+                    "loading existing event {} failed during upsert; refusing to recreate it under a fresh id",
+                    self.id
+                )));
+            }
+        };
+        if let Some(mut old_event) = old_event {
             if old_event.node_id != self.node_id
                 || old_event.board_id != self.board_id
                 || !canary_equal(&old_event.canary, &self.canary)
@@ -600,15 +623,41 @@ impl Event {
             .await?
             .as_generic();
 
-        let event_path = match version {
-            Some(version) => storage_root
-                .child("versions")
-                .child(self.id.clone())
-                .child(format!("{}.{}.{}", version.0, version.1, version.2)),
-            None => storage_root.child(format!("{}.event", self.id)),
+        let proto = self.to_proto();
+        let Some(version) = version else {
+            let event_path = storage_root.child(format!("{}.event", self.id));
+            compress_to_file(store, event_path, &proto).await?;
+            return Ok(());
         };
 
-        compress_to_file(store, event_path, &self.to_proto()).await?;
+        // Archived versions are immutable, like board snapshots: a create-only
+        // write means two racing publishers cannot destroy each other's slot.
+        // An identical occupant is success — it is also the crash-recovery path
+        // where an earlier upsert archived this version but died before writing
+        // the live object; without it the event would wedge unsaveable.
+        let event_path = storage_root
+            .child("versions")
+            .child(self.id.clone())
+            .child(format!("{}.{}.{}", version.0, version.1, version.2));
+        if let Err(create_error) =
+            compress_to_file_create(store.clone(), event_path.clone(), &proto).await
+        {
+            let existing: flow_like_types::Result<proto::Event> =
+                from_compressed(store, event_path).await;
+            match existing {
+                Ok(existing) if existing == proto => {}
+                Ok(_) => {
+                    return Err(flow_like_types::anyhow!(
+                        "archived version {}.{}.{} of event {} already exists with different content; refusing to overwrite it",
+                        version.0,
+                        version.1,
+                        version.2,
+                        self.id
+                    ));
+                }
+                Err(_) => return Err(create_error),
+            }
+        }
         Ok(())
     }
 
@@ -650,8 +699,143 @@ impl Event {
 
 #[cfg(test)]
 mod tests {
-    use super::{ChatEventParameters, EventPayload};
+    use super::{ChatEventParameters, Event, EventPayload, load_error_is_not_found};
+    use crate::state::{FlowLikeConfig, FlowLikeState};
+    use flow_like_storage::{
+        Path,
+        files::store::FlowLikeStore,
+        object_store::{self, PutPayload},
+    };
+    use flow_like_types::tokio;
     use serde_json::json;
+    use std::{collections::HashMap, sync::Arc, time::SystemTime};
+
+    async fn test_app() -> crate::app::App {
+        let mut config = FlowLikeConfig::new();
+        config.register_app_meta_store(FlowLikeStore::Other(Arc::new(
+            object_store::memory::InMemory::new(),
+        )));
+        config.register_app_storage_store(FlowLikeStore::Other(Arc::new(
+            object_store::memory::InMemory::new(),
+        )));
+        let state = Arc::new(FlowLikeState::new(
+            config,
+            crate::utils::http::HTTPClient::new_without_refetch(),
+        ));
+        crate::app::App::new(None, crate::bit::Metadata::default(), vec![], state)
+            .await
+            .unwrap()
+    }
+
+    fn storage_event(id: &str) -> Event {
+        Event {
+            id: id.to_string(),
+            name: "Storage Fixture".to_string(),
+            description: String::new(),
+            board_id: String::new(),
+            board_version: None,
+            node_id: String::new(),
+            variables: HashMap::new(),
+            config: Vec::new(),
+            active: false,
+            canary: None,
+            priority: 0,
+            event_type: "quick_action".to_string(),
+            notes: None,
+            event_version: (0, 0, 0),
+            created_at: SystemTime::UNIX_EPOCH,
+            updated_at: SystemTime::UNIX_EPOCH,
+            default_page_id: None,
+            inputs: Vec::new(),
+            route: None,
+            is_default: false,
+            execution_mode: super::EventExecutionMode::Local,
+            exposure: super::EventExposure::Public,
+            correlation_mappings: None,
+        }
+    }
+
+    #[test]
+    fn load_error_classification_only_treats_missing_objects_as_absent() {
+        let not_found: flow_like_types::Error = object_store::Error::NotFound {
+            path: "apps/a/events/e.event".to_string(),
+            source: "gone".into(),
+        }
+        .into();
+        assert!(load_error_is_not_found(&not_found));
+        assert!(load_error_is_not_found(
+            &not_found.context("loading event failed")
+        ));
+
+        assert!(!load_error_is_not_found(&flow_like_types::anyhow!(
+            "connection reset"
+        )));
+        let other_store_error: flow_like_types::Error = object_store::Error::Generic {
+            store: "s3",
+            source: "throttled".into(),
+        }
+        .into();
+        assert!(!load_error_is_not_found(&other_store_error));
+    }
+
+    #[tokio::test]
+    async fn archived_event_versions_are_immutable() {
+        let app = test_app().await;
+        let event = storage_event("evt-immutable");
+
+        event.save(&app, Some((1, 0, 0))).await.unwrap();
+        // The identical occupant is the crash-recovery path: archiving again
+        // after a died live-write must not wedge the event.
+        event.save(&app, Some((1, 0, 0))).await.unwrap();
+
+        let mut changed = event.clone();
+        changed.name = "Different Content".to_string();
+        let error = changed.save(&app, Some((1, 0, 0))).await.unwrap_err();
+        assert!(
+            error.to_string().contains("refusing to overwrite"),
+            "unexpected error: {error:#}"
+        );
+
+        // The live object stays last-write-wins.
+        changed.save(&app, None).await.unwrap();
+        event.save(&app, None).await.unwrap();
+        let live = Event::load(&event.id, &app, None).await.unwrap();
+        assert_eq!(live.name, event.name);
+    }
+
+    #[tokio::test]
+    async fn upsert_creates_on_absence_but_refuses_unreadable_events() {
+        let app = test_app().await;
+
+        let mut fresh = storage_event("evt-upsert");
+        let created = fresh.upsert(&app, None, true).await.unwrap();
+        assert_eq!(created.id, "evt-upsert");
+        assert_eq!(created.event_version, (0, 0, 0));
+
+        // Corrupt the live object: the next upsert must surface the read
+        // failure instead of forking the event under a fresh id.
+        let store = FlowLikeState::project_meta_store(app.app_state.as_ref().unwrap())
+            .await
+            .unwrap()
+            .as_generic();
+        let live_path = Path::from("apps")
+            .child(app.id.clone())
+            .child("events")
+            .child("evt-upsert.event");
+        store
+            .put(&live_path, PutPayload::from_static(b"not lz4 protobuf"))
+            .await
+            .unwrap();
+
+        let mut update = storage_event("evt-upsert");
+        update.name = "Update Attempt".to_string();
+        let error = update.upsert(&app, None, true).await.unwrap_err();
+        assert!(
+            format!("{error:#}").contains("refusing to recreate"),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(update.id, "evt-upsert");
+    }
 
     #[test]
     fn chat_event_parameters_default_presentation_fields_to_none() {


### PR DESCRIPTION
This pull request introduces two main sets of changes: (1) a compatibility shim for ONNX Runtime on Linux to address glibc and libstdc++ symbol issues, and (2) improvements to AWS credential policy handling, especially for S3 Express directory buckets, including policy size optimizations and more tolerant handling of missing or invalid page hooks in the prerun extraction logic.

**ONNX Runtime Linux Compatibility:**

* Added `.github/scripts/ort-glibc-compat.c` and `.github/scripts/prepare-ort-glibc-compat.sh` to provide missing glibc and libstdc++ symbols for ONNX Runtime on Linux runners with older toolchains, ensuring successful linking and compatibility with prebuilt ONNX Runtime archives. The script is conditionally invoked in the workflow before the Rust cache step. [[1]](diffhunk://#diff-2b3305efa309786ffaef0c7db38d34625797eee5d80809035844ca996efcd2b0R1-R72) [[2]](diffhunk://#diff-c71a0799262e763d4ee238a844f89d9430dd323a4cc09865ebf737fcf39c4f99R1-R77) [[3]](diffhunk://#diff-f7bb11da4daed6ccaceec672bf18a5ddd48a7afde778745ee203d8968598a73cR252-R258)

**AWS Credentials Policy Handling:**

* Refactored the construction of server execution policies to distinguish between standard and S3 Express directory meta buckets, emitting only the necessary IAM statements for each to avoid exceeding the AssumeRole packed policy size limit. This includes a new helper (`meta_bucket_express_zone`) to cache and determine the bucket type from environment variables, and corresponding changes in tests to cover both variants. [[1]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959R233) [[2]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959R307-R327) [[3]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959R528-L523) [[4]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959L541-R556) [[5]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959L555-R570) [[6]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959L571-R591) [[7]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959L586-R623) [[8]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959L603-R653) [[9]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959R1306) [[10]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959L1335-R1365) [[11]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959R1388-R1428) [[12]](diffhunk://#diff-e1d5a5fdfa673fd8d4d8d5784b31e67d8875e7bb38a349808d6baeb0f3448959R1459)

**Prerun Extraction Robustness:**

* Made the prerun extraction logic for page hooks (intervals, lifecycle events, and actions) tolerant of missing or invalid node references by logging a warning and skipping the non-executable hook, rather than failing the entire page extraction. This prevents a single stale reference from making a page unloadable. [[1]](diffhunk://#diff-ea1d6dec432cd1054669aec30bd177cd10899bce42133b97083c02fcfec08287L1025-R1049) [[2]](diffhunk://#diff-ea1d6dec432cd1054669aec30bd177cd10899bce42133b97083c02fcfec08287L1875-R1890) [[3]](diffhunk://#diff-ea1d6dec432cd1054669aec30bd177cd10899bce42133b97083c02fcfec08287L2560-R2583)