### PR TITLE
feat: implement app widget source for declarative widgets

### DIFF
--- a/packages/api/src/credentials/aws_credentials.rs
+++ b/packages/api/src/credentials/aws_credentials.rs
@@ -232,7 +232,6 @@ impl AwsRuntimeCredentials {
                 &runs_prefix,
                 &temporary_user_prefix,
                 &temporary_global_prefix,
-                meta_express,
             ),
             CredentialsAccess::ShadowExecute => shadow_execute_policy(
                 self,
@@ -241,7 +240,6 @@ impl AwsRuntimeCredentials {
                 &runs_prefix,
                 &temporary_user_prefix,
                 &temporary_global_prefix,
-                meta_express,
             ),
             CredentialsAccess::ReadLogs => read_logs_policy(self, &runs_prefix),
         };
@@ -488,12 +486,11 @@ struct KmsScope {
 impl KmsScope {
     fn of(mode: &CredentialsAccess) -> Self {
         Self {
+            // The executor modes never open the meta bucket: boards arrive as
+            // presigned artifacts, widgets via the hub.
             meta: matches!(
                 mode,
-                CredentialsAccess::EditApp
-                    | CredentialsAccess::ReadApp
-                    | CredentialsAccess::ServerExecute
-                    | CredentialsAccess::ShadowExecute
+                CredentialsAccess::EditApp | CredentialsAccess::ReadApp
             ),
             // Every mode but `ReadLogs` works on app or user content.
             content: !matches!(mode, CredentialsAccess::ReadLogs),
@@ -833,6 +830,12 @@ fn invoke_read_write_policy(
     policy
 }
 
+/// The executor's own grant: app and user content, scratch, and append-only
+/// run logs. Nothing on the meta bucket — the board reaches the executor as a
+/// presigned compiled artifact and widgets come from the hub, so this
+/// credential never needs to address meta at all. On a directory bucket that
+/// distinction is the whole game: `CreateSession` cannot be scoped below the
+/// bucket, so the only meta grant that is not bucket-wide is none.
 fn server_execute_policy(
     credentials: &AwsRuntimeCredentials,
     apps_prefix: &str,
@@ -840,15 +843,8 @@ fn server_execute_policy(
     runs_prefix: &str,
     temporary_user_prefix: &str,
     temporary_global_prefix: &str,
-    meta_express: bool,
 ) -> flow_like_types::Value {
-    // Draft artifacts (compiled boards, exact `.board` snapshots, prerun
-    // manifests) live under `tmp/apps/{app_id}/` on the meta bucket so
-    // lifecycle rules on `tmp/` reclaim them. The executor gets the same
-    // read-only grant there as on `apps/{app_id}` — only the API writes
-    // drafts, which anchors `entry_authority_revision`.
-    let draft_meta_prefix = format!("tmp/{apps_prefix}");
-    let mut statements = vec![
+    let statements = vec![
         json!({
           "Effect": "Allow",
           "Action": [
@@ -914,55 +910,6 @@ fn server_execute_policy(
           ],
         }),
     ];
-    if meta_express {
-        // On a directory bucket the session token — not per-object IAM —
-        // authorizes every zonal request, so the `s3:*` meta statements would
-        // never be evaluated; emitting them anyway blew the AssumeRole packed
-        // policy budget. Pin the session to ReadOnly so this mode cannot
-        // write the meta bucket.
-        statements.push(json!({
-          "Effect": "Allow",
-          "Action": [
-              "s3express:CreateSession",
-          ],
-          "Resource": [
-              "*"
-          ],
-          "Condition": {
-              "StringEquals": {
-                  "s3express:SessionMode": "ReadOnly"
-              }
-          }
-        }));
-    } else {
-        statements.push(json!({
-          "Effect": "Allow",
-          "Action": [
-              "s3:ListBucket"
-          ],
-          "Resource": [
-              format!("arn:aws:s3:::{}", credentials.meta_bucket)
-          ],
-          "Condition": {
-              "StringLike": {
-                  "s3:prefix": [
-                      format!("{}/*", apps_prefix),
-                      format!("{}/*", draft_meta_prefix)
-                  ]
-              }
-          }
-        }));
-        statements.push(json!({
-          "Effect": "Allow",
-          "Action": [
-              "s3:GetObject"
-          ],
-          "Resource": [
-              format!("arn:aws:s3:::{}/{}/*", credentials.meta_bucket, apps_prefix),
-              format!("arn:aws:s3:::{}/{}/*", credentials.meta_bucket, draft_meta_prefix),
-          ],
-        }));
-    }
     json!({
         "Version": "2012-10-17",
         "Statement": statements,
@@ -982,7 +929,6 @@ fn shadow_execute_policy(
     runs_prefix: &str,
     temporary_user_prefix: &str,
     temporary_global_prefix: &str,
-    meta_express: bool,
 ) -> flow_like_types::Value {
     let mut policy = server_execute_policy(
         credentials,
@@ -991,7 +937,6 @@ fn shadow_execute_policy(
         runs_prefix,
         temporary_user_prefix,
         temporary_global_prefix,
-        meta_express,
     );
 
     // Statement 1 is the content-bucket object statement (see
@@ -1670,78 +1615,37 @@ mod tests {
     }
 
     #[test]
-    fn test_aws_server_execute_grants_meta_read_only() {
+    /// The executor's board arrives as a presigned compiled artifact and its
+    /// widgets come from the hub, so its credential must not be able to
+    /// address the meta bucket at all — on a directory bucket any
+    /// `CreateSession` grant is bucket-wide, so "none" is the only scope.
+    #[test]
+    fn test_aws_server_execute_grants_no_meta_access() {
         let creds = test_aws_runtime_credentials();
-        let app_prefix = "apps/app-1";
         let policy = server_execute_policy(
             &creds,
-            app_prefix,
+            "apps/app-1",
             "users/user-1/apps/app-1",
             "runs/app-1",
             "tmp/user/user-1/apps/app-1",
             "tmp/global/apps/app-1",
-            false,
         );
         let statements = policy["Statement"]
             .as_array()
             .expect("policy statements should be an array");
-        let meta_object_statement = statements
-            .iter()
-            .find(|statement| {
-                statement["Resource"]
-                    .to_string()
-                    .contains("meta-secret/apps")
-            })
-            .expect("server execute should include meta object access");
-        let meta_list_statement = statements
-            .iter()
-            .find(|statement| {
-                statement["Resource"]
-                    .to_string()
-                    .contains("arn:aws:s3:::meta-secret")
-                    && statement["Condition"].to_string().contains(app_prefix)
-            })
-            .expect("server execute should include app-scoped meta listing");
-        let meta_actions = meta_object_statement["Action"].to_string();
-        let meta_resources = meta_object_statement["Resource"].to_string();
-        let meta_list_actions = meta_list_statement["Action"].to_string();
-        let meta_list_prefixes = meta_list_statement["Condition"].to_string();
         for statement in statements {
-            let actions = statement["Action"].to_string();
-            if statement["Resource"].to_string().contains("meta-secret") {
-                assert!(
-                    !actions.contains("PutObject") && !actions.contains("DeleteObject"),
-                    "no ServerExecute statement may write the meta bucket: {statement}"
-                );
-            }
+            assert!(
+                !statement["Resource"].to_string().contains("meta-secret"),
+                "ServerExecute must not name the meta bucket: {statement}"
+            );
         }
-        let policy = to_string(&policy).expect("policy should serialize");
-        let draft_artifact =
-            flow_like::flow::compiled::draft_artifact_path("app-1", "board-1", "etag", &[7; 32])
-                .to_string();
-        let other_app_artifact =
-            flow_like::flow::compiled::draft_artifact_path("app-10", "board-1", "etag", &[7; 32])
-                .to_string();
-
-        assert!(policy.contains("meta-secret/apps/app-1/*"));
-        assert!(meta_actions.contains("GetObject"));
-        assert!(meta_list_actions.contains("ListBucket"));
-        assert!(draft_artifact.starts_with("tmp/apps/app-1/"));
-        assert!(!other_app_artifact.starts_with("tmp/apps/app-1/"));
+        let json = to_string(&policy).expect("policy should serialize");
         assert!(
-            meta_resources.contains("meta-secret/tmp/apps/app-1/*"),
-            "draft artifacts under tmp/apps must stay readable: {meta_resources}"
+            !json.contains("s3express"),
+            "ServerExecute must not be able to open an express session: {json}"
         );
-        assert!(
-            meta_list_prefixes.contains("tmp/apps/app-1/*"),
-            "draft artifacts under tmp/apps must stay listable: {meta_list_prefixes}"
-        );
-        assert!(
-            !policy.to_string().contains("s3express"),
-            "a standard meta bucket needs no express statements"
-        );
-        assert!(policy.contains("content-data/apps/app-1/*"));
-        assert!(policy.contains("logs/runs/app-1/*"));
+        assert!(json.contains("content-data/apps/app-1/*"));
+        assert!(json.contains("logs/runs/app-1/*"));
         let logs_actions = statements
             .iter()
             .find(|statement| statement["Resource"].to_string().contains("logs/runs"))
@@ -1751,14 +1655,6 @@ mod tests {
         assert!(
             !logs_actions.contains("DeleteObject"),
             "ServerExecute run logs are append-only"
-        );
-        assert!(
-            !meta_actions.contains("PutObject"),
-            "ServerExecute must not grant meta writes"
-        );
-        assert!(
-            !meta_actions.contains("DeleteObject"),
-            "ServerExecute must not grant meta deletes"
         );
     }
 
@@ -1776,7 +1672,6 @@ mod tests {
             "runs/app-1",
             "tmp/user/user-1/apps/app-1",
             "tmp/global/apps/app-1",
-            false,
         );
         let statements = policy["Statement"]
             .as_array()
@@ -1825,25 +1720,21 @@ mod tests {
         let tmp_user = "tmp/user/auth0|64c9f0aa11bb22cc33dd44ee/apps/v8f5p73w00itor03zlrai22w";
         let tmp_global = "tmp/global/apps/v8f5p73w00itor03zlrai22w";
 
-        for express in [true, false] {
-            let policy =
-                shadow_execute_policy(&creds, app, user, runs, tmp_user, tmp_global, express);
-            let json = to_string(&policy).expect("policy should serialize");
-            assert!(
-                json.len() < 2000,
-                "{} ShadowExecute policy grew to {} chars",
-                if express { "express" } else { "standard" },
-                json.len()
-            );
-        }
+        let policy = shadow_execute_policy(&creds, app, user, runs, tmp_user, tmp_global);
+        let json = to_string(&policy).expect("policy should serialize");
+        assert!(
+            json.len() < 2000,
+            "ShadowExecute policy grew to {} chars",
+            json.len()
+        );
     }
 
-    /// On an express meta bucket the CreateSession token authorizes every
-    /// zonal request, so the per-object meta statements are dead weight — and
-    /// carrying both flavors once pushed AssumeRole past its packed-policy
-    /// budget in production (PackedPolicyTooLargeException at dispatch).
+    /// Carrying meta statements once pushed AssumeRole past its packed-policy
+    /// budget in production (PackedPolicyTooLargeException at dispatch). With
+    /// the meta grant gone entirely the policy is smaller than either old
+    /// flavor; keep it that way.
     #[test]
-    fn test_aws_server_execute_express_variant_stays_within_policy_budget() {
+    fn test_aws_server_execute_stays_within_policy_budget() {
         let creds = test_aws_runtime_credentials();
         // Realistic id lengths: generated app ids and IdP subjects are long,
         // and every prefix repeats them several times.
@@ -1853,29 +1744,16 @@ mod tests {
         let tmp_user = "tmp/user/auth0|64c9f0aa11bb22cc33dd44ee/apps/v8f5p73w00itor03zlrai22w";
         let tmp_global = "tmp/global/apps/v8f5p73w00itor03zlrai22w";
 
-        let express = server_execute_policy(&creds, app, user, runs, tmp_user, tmp_global, true);
-        let express_json = to_string(&express).expect("policy should serialize");
-        assert!(
-            !express_json.contains("arn:aws:s3:::meta-secret"),
-            "express meta access flows through CreateSession, not per-object IAM"
-        );
-        assert!(express_json.contains("s3express:CreateSession"));
-        assert!(express_json.contains("ReadOnly"));
-
-        let standard = server_execute_policy(&creds, app, user, runs, tmp_user, tmp_global, false);
-        let standard_json = to_string(&standard).expect("policy should serialize");
-
+        let policy = server_execute_policy(&creds, app, user, runs, tmp_user, tmp_global);
+        let json = to_string(&policy).expect("policy should serialize");
+        assert!(!json.contains("meta-secret"));
+        assert!(!json.contains("s3express"));
         // STS caps the plaintext at 2048 characters and packs it into a
-        // shared binary quota; both variants must keep real headroom.
+        // shared binary quota; keep real headroom.
         assert!(
-            express_json.len() < 1600,
-            "express ServerExecute policy grew to {} chars",
-            express_json.len()
-        );
-        assert!(
-            standard_json.len() < 1900,
-            "standard ServerExecute policy grew to {} chars",
-            standard_json.len()
+            json.len() < 1600,
+            "ServerExecute policy grew to {} chars",
+            json.len()
         );
     }
 
@@ -1909,11 +1787,9 @@ mod tests {
                 "runs/app-1",
                 "tmp/user/user-1/apps/app-1",
                 "tmp/global/apps/app-1",
-                true,
-            ))
-            .as_deref(),
-            Some("\"ReadOnly\""),
-            "ServerExecute only reads the meta bucket and must not obtain a ReadWrite session"
+            )),
+            None,
+            "ServerExecute must not be able to open any express session"
         );
         assert_eq!(
             create_session_mode(edit_app_policy(&creds, apps_prefix)).as_deref(),

--- a/packages/api/src/credentials/azure_credentials.rs
+++ b/packages/api/src/credentials/azure_credentials.rs
@@ -324,10 +324,11 @@ impl AzureRuntimeCredentials {
             )
         };
 
-        // Only ServerExecute reads draft artifacts, mirroring the AWS/GCP/R2
-        // executor policies; every other mode leaves both slots empty.
-        let mut draft_meta_sas_token = None;
-        let mut draft_meta_path_prefix = None;
+        // No mode reads draft artifacts from storage any more — the executor
+        // receives its compiled board as a presigned artifact — so both slots
+        // stay empty. Kept on the struct so older executors deserialise.
+        let draft_meta_sas_token = None;
+        let draft_meta_path_prefix = None;
 
         // Determine which containers and paths need SAS tokens based on access mode
         let (
@@ -610,30 +611,9 @@ impl AzureRuntimeCredentials {
                 )
             }
             CredentialsAccess::ServerExecute => {
-                let (meta_prefix, meta_permissions) = server_execute_meta_scope(app_id);
-                let meta_sas = generate_directory_sas(
-                    &self.account_name,
-                    &self.meta_container,
-                    &meta_prefix,
-                    meta_permissions,
-                    &expiry_str,
-                    &issuer,
-                )?;
-                // Draft artifacts (compiled boards, exact `.board` snapshots,
-                // prerun manifests) live under `tmp/apps/{app_id}` on the meta
-                // container. A directory SAS signs exactly one directory, so
-                // unlike the AWS/GCP prefix lists this needs a second,
-                // read-only token beside the `apps/{app_id}` meta SAS.
-                let (draft_prefix, draft_permissions) = server_execute_draft_meta_scope(app_id);
-                draft_meta_sas_token = Some(generate_directory_sas(
-                    &self.account_name,
-                    &self.meta_container,
-                    &draft_prefix,
-                    draft_permissions,
-                    &expiry_str,
-                    &issuer,
-                )?);
-                draft_meta_path_prefix = Some(draft_prefix);
+                // No meta SAS: the executor's board arrives as a presigned
+                // compiled artifact and its widgets come from the hub, so the
+                // run credential never addresses the meta container.
                 let app_content_sas = generate_directory_sas(
                     &self.account_name,
                     &self.content_container,
@@ -661,7 +641,7 @@ impl AzureRuntimeCredentials {
                     &issuer,
                 )?;
                 (
-                    Some(meta_sas),
+                    None,
                     Some(app_content_sas),
                     Some(user_content_sas),
                     Some(logs_sas),
@@ -674,26 +654,8 @@ impl AzureRuntimeCredentials {
                 // ServerExecute with app/user content writes dropped: a shadow
                 // run reads live content ("rl") but may never mutate it.
                 // Scratch stays read-write and run logs stay append-only so
-                // the shadow run itself is recorded.
-                let (meta_prefix, meta_permissions) = server_execute_meta_scope(app_id);
-                let meta_sas = generate_directory_sas(
-                    &self.account_name,
-                    &self.meta_container,
-                    &meta_prefix,
-                    meta_permissions,
-                    &expiry_str,
-                    &issuer,
-                )?;
-                let (draft_prefix, draft_permissions) = server_execute_draft_meta_scope(app_id);
-                draft_meta_sas_token = Some(generate_directory_sas(
-                    &self.account_name,
-                    &self.meta_container,
-                    &draft_prefix,
-                    draft_permissions,
-                    &expiry_str,
-                    &issuer,
-                )?);
-                draft_meta_path_prefix = Some(draft_prefix);
+                // the shadow run itself is recorded. Like ServerExecute, no
+                // meta SAS.
                 let app_content_sas = generate_directory_sas(
                     &self.account_name,
                     &self.content_container,
@@ -719,7 +681,7 @@ impl AzureRuntimeCredentials {
                     &issuer,
                 )?;
                 (
-                    Some(meta_sas),
+                    None,
                     Some(app_content_sas),
                     Some(user_content_sas),
                     Some(logs_sas),
@@ -972,26 +934,6 @@ impl AzureUserDelegationSasIssuer {
 /// Read-only meta scope for the executor: version artifacts and boards under
 /// `apps/{app_id}`.
 ///
-/// Draft artifacts live under `tmp/apps/{app_id}` and are covered by the
-/// separate SAS from [`server_execute_draft_meta_scope`] — an Azure directory
-/// SAS signs exactly one directory, and widening this one to the container
-/// root would expose every app's metadata.
-#[cfg(feature = "azure")]
-fn server_execute_meta_scope(app_id: &str) -> (String, &'static str) {
-    (format!("apps/{app_id}"), "rl")
-}
-
-/// Read-only draft-artifact scope for the executor: compiled drafts, exact
-/// `.board` snapshots and prerun manifests under `tmp/apps/{app_id}`
-/// (see `flow_like::flow::compiled::draft_artifact_dir`), lifecycle-reclaimed
-/// via the `tmp/` prefix. Read+list only — only the API writes drafts, which
-/// anchors `entry_authority_revision`. The executor routes meta reads under
-/// this directory through the token (`AzureSharedCredentials::to_store_type`).
-#[cfg(feature = "azure")]
-fn server_execute_draft_meta_scope(app_id: &str) -> (String, &'static str) {
-    (format!("tmp/apps/{app_id}"), "rl")
-}
-
 /// Generates an HTTPS-only directory SAS for an HNS/ADLS Gen2 path.
 /// The secure Azure API reaches this through a Microsoft Entra user delegation
 /// key; shared-key signing remains only for backward-compatible callers that
@@ -1441,80 +1383,25 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn test_azure_server_execute_has_meta_read_and_content_write() {
+    /// The executor's board arrives as a presigned compiled artifact and its
+    /// widgets come from the hub, so ServerExecute carries no meta SAS at all —
+    /// neither for `apps/{app_id}` nor for the draft directory.
+    async fn test_azure_server_execute_has_no_meta_sas_and_content_write() {
         let creds = test_azure_runtime_credentials();
         let scoped = creds
             .scoped_credentials_for_test(TEST_SUB, TEST_APP_ID, CredentialsAccess::ServerExecute)
             .await
             .expect("server execute credentials should be generated");
 
-        let meta = scoped
-            .meta_sas_token
-            .as_deref()
-            .expect("ServerExecute should include meta read credentials");
-        assert_eq!(sas_permissions(meta), Some("rl"));
-        assert_eq!(sas_directory_depth(meta), Some(2));
-        let (meta_prefix, meta_permissions) = server_execute_meta_scope(TEST_APP_ID);
-        assert_eq!(meta_prefix, format!("apps/{TEST_APP_ID}"));
-        assert_eq!(meta_permissions, "rl");
-
-        // Draft artifacts live under tmp/apps/{app_id}, which a directory SAS
-        // for apps/{app_id} cannot cover — ServerExecute therefore carries a
-        // second meta SAS scoped to exactly that directory, read+list only:
-        // only the API writes drafts (the trust anchor for
-        // `entry_authority_revision`).
-        let draft_meta = scoped
-            .draft_meta_sas_token
-            .as_deref()
-            .expect("ServerExecute should include draft-artifact read credentials");
-        let (draft_prefix, draft_permissions) = server_execute_draft_meta_scope(TEST_APP_ID);
-        assert_eq!(draft_prefix, format!("tmp/apps/{TEST_APP_ID}"));
-        assert_eq!(draft_permissions, "rl");
-        assert_eq!(sas_permissions(draft_meta), Some("rl"));
-        let draft_meta_permissions =
-            sas_permissions(draft_meta).expect("draft SAS should carry permissions");
         assert!(
-            !draft_meta_permissions.contains('w')
-                && !draft_meta_permissions.contains('d')
-                && !draft_meta_permissions.contains('a')
-                && !draft_meta_permissions.contains('c'),
-            "the draft SAS must never grant a write, got {draft_meta_permissions}"
+            scoped.meta_sas_token.is_none(),
+            "ServerExecute must not carry a meta SAS"
         );
-        // tmp/apps/{app_id}
-        assert_eq!(sas_directory_depth(draft_meta), Some(3));
-        assert_eq!(
-            scoped.draft_meta_path_prefix.as_deref(),
-            Some(draft_prefix.as_str()),
-            "the executor routes meta reads by this prefix"
+        assert!(
+            scoped.draft_meta_sas_token.is_none(),
+            "ServerExecute must not carry a draft-artifact SAS"
         );
-
-        let draft_artifact = flow_like::flow::compiled::draft_artifact_path(
-            TEST_APP_ID,
-            "board-1",
-            "etag",
-            &[7; 32],
-        )
-        .to_string();
-        let draft_source =
-            flow_like::flow::compiled::draft_source_path(TEST_APP_ID, "board-1", "etag")
-                .to_string();
-        let draft_manifest =
-            flow_like::flow::compiled::draft_manifest_path(TEST_APP_ID, "board-1", "etag")
-                .to_string();
-        let other_app_artifact = flow_like::flow::compiled::draft_artifact_path(
-            &format!("{TEST_APP_ID}-other"),
-            "board-1",
-            "etag",
-            &[7; 32],
-        )
-        .to_string();
-        for path in [&draft_artifact, &draft_source, &draft_manifest] {
-            assert!(
-                path.starts_with(&format!("{draft_prefix}/")),
-                "{path} must be inside the ServerExecute draft meta scope {draft_prefix}"
-            );
-        }
-        assert!(!other_app_artifact.starts_with(&format!("{draft_prefix}/")));
+        assert!(scoped.draft_meta_path_prefix.is_none());
 
         let content = scoped
             .content_sas_token
@@ -1562,11 +1449,11 @@ mod integration_tests {
             .expect("ShadowExecute should include user content read credentials");
         assert_eq!(sas_permissions(user_content), Some("rl"));
 
-        let meta = scoped
-            .meta_sas_token
-            .as_deref()
-            .expect("ShadowExecute still reads the board/event definition");
-        assert_eq!(sas_permissions(meta), Some("rl"));
+        assert!(
+            scoped.meta_sas_token.is_none(),
+            "ShadowExecute receives its board as a presigned artifact, not a meta SAS"
+        );
+        assert!(scoped.draft_meta_sas_token.is_none());
 
         let logs = scoped
             .logs_sas_token

--- a/packages/api/src/credentials/gcp_credentials.rs
+++ b/packages/api/src/credentials/gcp_credentials.rs
@@ -363,7 +363,6 @@ impl GcpRuntimeCredentials {
                         vec![log_prefix.clone()],
                         GcpAccess::Append,
                     ),
-                    server_execute_meta_rule(&self.meta_bucket, &apps_prefix),
                 ],
             )
             .await?
@@ -393,7 +392,6 @@ impl GcpRuntimeCredentials {
                         vec![log_prefix.clone()],
                         GcpAccess::Append,
                     ),
-                    server_execute_meta_rule(&self.meta_bucket, &apps_prefix),
                 ],
             )
             .await?
@@ -560,7 +558,6 @@ impl GcpRuntimeCredentials {
                         vec![log_prefix.clone()],
                         GcpAccess::Append,
                     ),
-                    server_execute_meta_rule(&self.meta_bucket, &apps_prefix),
                 ],
             )
             .await?
@@ -590,7 +587,6 @@ impl GcpRuntimeCredentials {
                         vec![log_prefix.clone()],
                         GcpAccess::Append,
                     ),
-                    server_execute_meta_rule(&self.meta_bucket, &apps_prefix),
                 ],
             )
             .await?
@@ -1108,19 +1104,6 @@ impl GcpAccessRule {
             access,
         }
     }
-}
-
-/// Read-only meta rule for the executor: version artifacts and boards under
-/// `apps/{app_id}/`, plus draft artifacts under `tmp/apps/{app_id}/` — the
-/// drafts are written only by the API (the trust anchor for
-/// `entry_authority_revision`) and reclaimed by lifecycle rules on `tmp/`.
-#[cfg(feature = "gcp")]
-fn server_execute_meta_rule(bucket: &str, apps_prefix: &str) -> GcpAccessRule {
-    GcpAccessRule::new(
-        bucket.to_string(),
-        vec![apps_prefix.to_string(), format!("tmp/{apps_prefix}")],
-        false,
-    )
 }
 
 #[cfg(feature = "gcp")]
@@ -1793,40 +1776,6 @@ mod tests {
             json.contains("ya29.scoped-token"),
             "Scoped credentials should include access token"
         );
-    }
-
-    #[test]
-    fn test_gcp_server_execute_can_read_app_scoped_draft_artifacts() {
-        let app_prefix = format!("apps/{TEST_APP_ID}");
-        let rule = server_execute_meta_rule("meta", &app_prefix);
-        let draft_artifact = flow_like::flow::compiled::draft_artifact_path(
-            TEST_APP_ID,
-            "board-1",
-            "etag",
-            &[7; 32],
-        )
-        .to_string();
-        let other_app_artifact = flow_like::flow::compiled::draft_artifact_path(
-            &format!("{TEST_APP_ID}-other"),
-            "board-1",
-            "etag",
-            &[7; 32],
-        )
-        .to_string();
-
-        assert_eq!(rule.bucket, "meta");
-        assert_eq!(
-            rule.prefixes,
-            vec![format!("{app_prefix}/"), format!("tmp/{app_prefix}/")]
-        );
-        assert_eq!(rule.access.roles(), &["inRole:roles/storage.objectViewer"]);
-        let condition = access_boundary_condition(&rule);
-        assert!(condition.contains("resource.name.startsWith"));
-        assert!(condition.contains("storage.googleapis.com/objectListPrefix"));
-        assert!(condition.contains(&format!("objects/{app_prefix}/")));
-        assert!(condition.contains(&format!("objects/tmp/{app_prefix}/")));
-        assert!(draft_artifact.starts_with(&format!("tmp/{app_prefix}/")));
-        assert!(!other_app_artifact.starts_with(&format!("tmp/{app_prefix}/")));
     }
 
     /// `startsWith` on an unanchored directory prefix leaks: `apps/app-1`

--- a/packages/api/src/credentials/r2_credentials.rs
+++ b/packages/api/src/credentials/r2_credentials.rs
@@ -278,19 +278,6 @@ impl R2RuntimeCredentials {
         })
     }
 
-    async fn scoped_server_meta_read_credentials(&self, sub: &str, app_id: &str) -> Result<Self> {
-        if sub.is_empty() || app_id.is_empty() {
-            return Err(anyhow!("Sub or App ID cannot be empty"));
-        }
-
-        crate::credentials::validate_path_component(sub, "sub")?;
-        crate::credentials::validate_path_component(app_id, "app_id")?;
-
-        let (permission, prefixes) = server_execute_meta_scope(app_id);
-        self.scoped_bucket_credentials(&self.meta_bucket, permission, prefixes, None, None)
-            .await
-    }
-
     async fn scoped_server_content_write_credentials(
         &self,
         sub: &str,
@@ -353,15 +340,19 @@ impl R2RuntimeCredentials {
         sub: &str,
         app_id: &str,
     ) -> Result<MixedRuntimeCredentials> {
-        let (meta, content, logs) = flow_like_types::tokio::join!(
-            self.scoped_server_meta_read_credentials(sub, app_id),
+        let (content, logs) = flow_like_types::tokio::join!(
             self.scoped_server_content_write_credentials(sub, app_id),
             self.scoped_server_logs_write_credentials(sub, app_id),
         );
+        let content = content?;
 
         Ok(MixedRuntimeCredentials {
-            meta: Box::new(RuntimeCredentials::R2(meta?)),
-            content: Box::new(RuntimeCredentials::R2(content?)),
+            // The executor opens no meta store: its board arrives as a
+            // presigned compiled artifact and widgets come from the hub. The
+            // mixed shape still wants a credential in the slot, so the content
+            // credential fills it — it cannot reach the meta bucket.
+            meta: Box::new(RuntimeCredentials::R2(content.clone())),
+            content: Box::new(RuntimeCredentials::R2(content)),
             logs: Box::new(RuntimeCredentials::R2(logs?)),
         })
     }
@@ -462,17 +453,6 @@ impl R2RuntimeCredentials {
         resp.result
             .ok_or_else(|| anyhow!("R2 temp credentials response missing result"))
     }
-}
-
-/// Read-only meta scope for the executor: version artifacts and boards under
-/// `apps/{app_id}/`, plus draft artifacts under `tmp/apps/{app_id}/` — the
-/// drafts are written only by the API (the trust anchor for
-/// `entry_authority_revision`) and reclaimed by lifecycle rules on `tmp/`.
-fn server_execute_meta_scope(app_id: &str) -> (&'static str, Vec<String>) {
-    (
-        "object-read-only",
-        vec![format!("apps/{app_id}/"), format!("tmp/apps/{app_id}/")],
-    )
 }
 
 fn scoped_content_path_prefixes(
@@ -661,23 +641,4 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_r2_server_execute_can_read_app_scoped_draft_artifacts() {
-        let (permission, prefixes) = server_execute_meta_scope("app-1");
-        let draft_artifact =
-            flow_like::flow::compiled::draft_artifact_path("app-1", "board-1", "etag", &[7; 32])
-                .to_string();
-        let other_app_artifact =
-            flow_like::flow::compiled::draft_artifact_path("app-10", "board-1", "etag", &[7; 32])
-                .to_string();
-
-        assert_eq!(permission, "object-read-only");
-        assert_eq!(
-            prefixes,
-            vec!["apps/app-1/".to_string(), "tmp/apps/app-1/".to_string()]
-        );
-        assert!(draft_artifact.starts_with(&prefixes[1]));
-        assert!(!other_app_artifact.starts_with(&prefixes[1]));
-        assert!(!other_app_artifact.starts_with(&prefixes[0]));
-    }
 }

--- a/packages/api/src/execution/compiled_artifacts.rs
+++ b/packages/api/src/execution/compiled_artifacts.rs
@@ -1,8 +1,10 @@
 //! Pre-dispatch compiled-artifact assurance.
 //!
-//! Executors are read-only on the meta store (AWS scopes them to GetObject),
-//! so the API guarantees the compiled artifact exists before handing a run to
-//! them. The check is designed to be near-free on the hot path:
+//! The executor holds no meta-store credential and has no board source other
+//! than the compiled artifact the dispatcher presigns for it, so the API
+//! guarantees that artifact exists — for every run — before dispatch, and the
+//! dispatcher refuses the run otherwise. The check is designed to be
+//! near-free on the hot path:
 //!
 //! 1. In-memory positive cache keyed by (app, board, version|etag, registry
 //!    fingerprint). ETag-bound Page runs still revalidate object existence
@@ -15,17 +17,32 @@
 //!    its ETag. Governed Page runs already carry the ETag they authorized.
 //! 3. On miss: compile from the API's prepared-board cache and persist.
 //!
-//! Ordinary runs treat this as a warm-up optimization because the executor can
-//! compile the current source in memory. An ETag-bound Page run fails dispatch
-//! if its exact artifact cannot be assured; substituting a newer source would
-//! violate the action contract.
+//! The registry compiled against is the one the executor will run with: the
+//! built-in catalog extended with the run's WASM node definitions (see
+//! [`crate::state::State::artifact_registry`]), so boards with WASM nodes
+//! compile here too — without the API ever loading a module.
 
 use crate::state::AppState;
 use flow_like::flow::board::Board;
 use flow_like::flow::compiled;
+use flow_like::state::{FlowNodeRegistry, FlowNodeRegistryInner};
+use flow_like_storage::object_store::ObjectStore;
 use flow_like_storage::{Path, object_store::Error as StoreError};
 use flow_like_types::anyhow;
-use flow_like_types::dispatch::ETAG_BOUND_LATEST_VERSION_SENTINEL;
+use flow_like_types::dispatch::{ETAG_BOUND_LATEST_VERSION_SENTINEL, WasmPackageRef};
+use flow_like_types::tokio::sync::RwLock;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// What the assurance established: the artifact's object key on the meta
+/// store, the source ETag it was compiled from (floating Latest runs; `None`
+/// for pinned versions) and the registry fingerprint in its header.
+#[derive(Clone, Debug)]
+pub struct EnsuredArtifact {
+    pub path: Path,
+    pub source_etag: Option<String>,
+    pub registry_fingerprint: [u8; 32],
+}
 
 fn require_selected_draft_etag(
     board_id: &str,
@@ -41,15 +58,17 @@ fn require_selected_draft_etag(
 }
 
 /// Ensure the compiled artifact for (board, version|latest) exists on the
-/// meta store and matches the API's registry fingerprint.
+/// meta store and matches the fingerprint of the registry the run will use.
 pub async fn ensure_compiled_artifact(
     state: &AppState,
     app_id: &str,
     board_id: &str,
     version: Option<(u32, u32, u32)>,
     expected_etag: Option<&str>,
-) -> flow_like_types::Result<()> {
-    let fingerprint = state.registry.fingerprint();
+    wasm_packages: Option<&HashMap<String, WasmPackageRef>>,
+) -> flow_like_types::Result<EnsuredArtifact> {
+    let registry = state.artifact_registry(wasm_packages).await?;
+    let fingerprint = registry.fingerprint();
     let fingerprint_hex = blake3::Hash::from_bytes(fingerprint).to_hex();
     let storage_root = Path::from("apps").child(app_id.to_string());
     let meta_store = state.meta_bucket.as_generic();
@@ -133,8 +152,14 @@ pub async fn ensure_compiled_artifact(
         }
     };
 
+    let ensured = EnsuredArtifact {
+        path: artifact_path.clone(),
+        source_etag: selected_draft_etag.clone(),
+        registry_fingerprint: fingerprint,
+    };
+
     if expected_etag.is_none() && state.compiled_artifact_cache.get(&cache_key).is_some() {
-        return Ok(());
+        return Ok(ensured);
     }
 
     // Lookup 2: a ranged GET of the envelope answers existence + format
@@ -144,7 +169,7 @@ pub async fn ensure_compiled_artifact(
         && header.registry_fingerprint == fingerprint
     {
         state.compiled_artifact_cache.insert(cache_key, ());
-        return Ok(());
+        return Ok(ensured);
     }
 
     // Miss: compile from the API's prepared-board cache and persist.
@@ -177,17 +202,29 @@ pub async fn ensure_compiled_artifact(
         cached.board.clone()
     };
 
-    // Boards with WASM nodes are compiled by the executor: only its registry
-    // carries the bundle's `on_update` behavior, so an API-built artifact
-    // would be rejected there anyway. Cache the decision — it is keyed by
-    // board content + fingerprint and flips on the next edit.
-    let has_wasm = board.has_wasm_nodes();
-    if has_wasm {
-        state.compiled_artifact_cache.insert(cache_key, ());
-        return Ok(());
-    }
+    // The prepared board was hydrated against the built-in registry, where
+    // `sync_board_node_schemas` skips nodes it cannot find — so a WASM node
+    // still carries whatever metadata, pin schemas and permissions were saved,
+    // not the package's current ones. Re-hydrate against the overlay registry
+    // so the artifact is what the executor's own registry would have produced.
+    let board = if board.has_wasm_nodes() && !Arc::ptr_eq(&registry, &state.registry) {
+        rehydrate_with_registry(
+            state,
+            meta_store.clone(),
+            app_id,
+            board_id,
+            &storage_root,
+            version,
+            expected_etag,
+            selected_draft_etag.as_deref(),
+            registry.clone(),
+        )
+        .await?
+    } else {
+        board
+    };
 
-    let compiled_board = compiled::compile::compile_board_with_catalog(&board, &state.registry)?;
+    let compiled_board = compiled::compile::compile_board_with_catalog(&board, &registry)?;
     let bytes = compiled::encode_artifact(&compiled_board, &fingerprint)?;
     compiled::persist_artifact(&meta_store, &artifact_path, purge_prefix, bytes).await?;
     state.compiled_artifact_cache.insert(cache_key, ());
@@ -197,7 +234,60 @@ pub async fn ensure_compiled_artifact(
         path = %artifact_path,
         "Compiled artifact ensured before dispatch"
     );
-    Ok(())
+    Ok(ensured)
+}
+
+/// Load the board's source again and hydrate it against `registry`, for boards
+/// whose prepared form was hydrated against a registry without their WASM
+/// nodes. The hydration state borrows the master state's stores and clients
+/// but gets its own registry handle, so the shared master state is never
+/// mutated. A floating source that moved since the HEAD that keyed the
+/// artifact is refused rather than compiled under the older ETag's path.
+#[allow(clippy::too_many_arguments)]
+async fn rehydrate_with_registry(
+    state: &AppState,
+    meta_store: Arc<dyn ObjectStore>,
+    app_id: &str,
+    board_id: &str,
+    storage_root: &Path,
+    version: Option<(u32, u32, u32)>,
+    expected_etag: Option<&str>,
+    selected_etag: Option<&str>,
+    registry: Arc<FlowNodeRegistryInner>,
+) -> flow_like_types::Result<Arc<Board>> {
+    let proto = if let Some(expected_etag) = expected_etag {
+        let source_path = compiled::draft_source_path(app_id, board_id, expected_etag);
+        flow_like::utils::compression::from_compressed(meta_store, source_path.clone())
+            .await
+            .map_err(|error| {
+                anyhow!(
+                    "exact source snapshot for Latest board {board_id} is unavailable at {source_path}: {error}"
+                )
+            })?
+    } else {
+        let (proto, meta) =
+            Board::load_proto_with_meta(meta_store, storage_root, board_id, version).await?;
+        let loaded_etag = meta
+            .e_tag
+            .ok_or_else(|| anyhow!("meta store returned no etag for board {board_id}"))?;
+        require_selected_draft_etag(board_id, selected_etag, &loaded_etag)?;
+        proto
+    };
+
+    let master = state.master_state(state).await?;
+    let mut hydration_state = master.for_execution_run();
+    hydration_state.node_registry = Arc::new(RwLock::new(FlowNodeRegistry {
+        node_registry: registry,
+        parent: None,
+    }));
+    let board = Board::from_loaded_proto(proto, storage_root.clone(), Arc::new(hydration_state)).await;
+    if board.id != board_id {
+        return Err(anyhow!(
+            "source for board {board_id} contains board {}",
+            board.id
+        ));
+    }
+    Ok(Arc::new(board))
 }
 
 #[cfg(test)]

--- a/packages/api/src/execution/dispatch.rs
+++ b/packages/api/src/execution/dispatch.rs
@@ -128,7 +128,9 @@ use flow_like_types::channel::ChannelGrant;
 use flow_like_types::create_id;
 #[cfg(feature = "lambda")]
 use flow_like_types::dispatch::DIRECT_LAMBDA_INVOKE_API_ID;
-use flow_like_types::dispatch::ETAG_BOUND_LATEST_VERSION_SENTINEL;
+use flow_like_types::dispatch::{CompiledArtifactRef, ETAG_BOUND_LATEST_VERSION_SENTINEL};
+
+use super::compiled_artifacts::EnsuredArtifact;
 
 use crate::channel::ChannelIssuer;
 use serde::{Deserialize, Serialize};
@@ -385,6 +387,10 @@ pub struct DispatchRequest {
     /// the request otherwise.
     #[serde(default)]
     pub shadow: bool,
+    /// The compiled board the executor will fetch. Left `None` by callers; the
+    /// dispatcher fills it after assuring and presigning the artifact.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<CompiledArtifactRef>,
 }
 
 /// Response from dispatch
@@ -422,19 +428,37 @@ pub enum DispatchError {
     Artifact(String),
 }
 
-/// Callback that guarantees the compiled artifact for (app, board, version)
-/// exists before a run is handed to a read-only executor. Installed once at
-/// router construction; see `execution::compiled_artifacts`.
+/// Callback that guarantees the compiled artifact for (app, board,
+/// version|etag, WASM package set) exists before a run is handed to the
+/// executor, and reports which object it is so the dispatcher can presign it.
+/// Installed once at router construction; see `execution::compiled_artifacts`.
 pub type ArtifactEnsurer = Arc<
     dyn Fn(
             String,
             String,
             Option<(u32, u32, u32)>,
             Option<String>,
-        ) -> futures::future::BoxFuture<'static, flow_like_types::Result<()>>
+            Option<std::collections::HashMap<String, flow_like_types::dispatch::WasmPackageRef>>,
+        ) -> futures::future::BoxFuture<'static, flow_like_types::Result<EnsuredArtifact>>
         + Send
         + Sync,
 >;
+
+/// How long the presigned artifact URL stays valid: long enough to outlive the
+/// queue a payload may sit in, exactly like the claim-check URL for the payload
+/// itself. Direct transports run immediately and get an hour.
+fn artifact_url_ttl(backend: &ExecutionBackend) -> std::time::Duration {
+    match backend {
+        #[cfg(feature = "storage-queue")]
+        ExecutionBackend::AzureQueue => crate::storage_queue::CLAIM_CHECK_URL_TTL,
+        #[cfg(feature = "pubsub")]
+        ExecutionBackend::PubSub => pubsub::CLAIM_CHECK_URL_TTL,
+        ExecutionBackend::Sqs | ExecutionBackend::SqsEventBridge => {
+            std::time::Duration::from_secs(86_400)
+        }
+        _ => std::time::Duration::from_secs(3_600),
+    }
+}
 
 /// Unified job dispatcher
 #[derive(Clone)]
@@ -552,6 +576,37 @@ impl Dispatcher {
         let _ = self.artifact_ensurer.set(ensurer);
     }
 
+    /// Presign the assured artifact for the executor. SigV4 signing is local
+    /// computation, so this adds no round trip after `ensure_artifact`.
+    async fn sign_artifact(
+        &self,
+        ensured: &EnsuredArtifact,
+        backend: &ExecutionBackend,
+    ) -> Result<CompiledArtifactRef, DispatchError> {
+        let staging = self.staging_bucket.as_ref().ok_or_else(|| {
+            DispatchError::Configuration(
+                "a staging store is required to sign compiled artifacts for the executor".into(),
+            )
+        })?;
+        let url = staging
+            .sign("GET", &ensured.path, artifact_url_ttl(backend))
+            .await
+            .map_err(|e| {
+                DispatchError::Artifact(format!(
+                    "failed to sign compiled artifact {}: {e}",
+                    ensured.path
+                ))
+            })?;
+        Ok(CompiledArtifactRef {
+            url: url.to_string(),
+            path: ensured.path.to_string(),
+            source_etag: ensured.source_etag.clone(),
+            registry_fingerprint: blake3::Hash::from_bytes(ensured.registry_fingerprint)
+                .to_hex()
+                .to_string(),
+        })
+    }
+
     /// The issuer that mints every dispatched run's channel grant.
     pub fn with_channel_issuer(mut self, issuer: Arc<ChannelIssuer>) -> Self {
         self.channels = Some(issuer);
@@ -604,10 +659,12 @@ impl Dispatcher {
     }
 
     /// Guarantee the compiled artifact exists before handing the run to the
-    /// executor. Ordinary runs retain the historical best-effort fallback.
-    /// An ETag-bound Page run fails closed because compiling a newer draft in
-    /// memory would violate its authorized contract.
-    async fn ensure_artifact(&self, request: &DispatchRequest) -> Result<(), DispatchError> {
+    /// executor, and say which object it is. Every run fails closed here: the
+    /// executor has no board source other than this artifact.
+    async fn ensure_artifact(
+        &self,
+        request: &DispatchRequest,
+    ) -> Result<EnsuredArtifact, DispatchError> {
         if request.board_version == Some(ETAG_BOUND_LATEST_VERSION_SENTINEL) {
             return Err(DispatchError::Artifact(
                 "the requested board version is reserved for ETag-bound Latest dispatch"
@@ -629,33 +686,20 @@ impl Dispatcher {
             ));
         }
         let Some(ensurer) = self.artifact_ensurer.get() else {
-            if request.board_etag.is_some() {
-                return Err(DispatchError::Artifact(
-                    "the dispatcher has no compiled-artifact assurer for an ETag-bound Page run"
-                        .to_string(),
-                ));
-            }
-            return Ok(());
+            return Err(DispatchError::Artifact(
+                "the dispatcher has no compiled-artifact assurer; no run can be dispatched"
+                    .to_string(),
+            ));
         };
-        if let Err(e) = ensurer(
+        ensurer(
             request.app_id.clone(),
             request.board_id.clone(),
             request.board_version,
             request.board_etag.clone(),
+            request.wasm_packages.clone(),
         )
         .await
-        {
-            if request.board_etag.is_some() {
-                return Err(DispatchError::Artifact(e.to_string()));
-            }
-            tracing::warn!(
-                app_id = %request.app_id,
-                board_id = %request.board_id,
-                error = %e,
-                "Pre-dispatch compiled-artifact check failed; executor will compile in memory"
-            );
-        }
-        Ok(())
+        .map_err(|e| DispatchError::Artifact(e.to_string()))
     }
 
     /// Dispatch an execution request to the configured sync/streaming backend (EXECUTION_BACKEND)
@@ -691,7 +735,8 @@ impl Dispatcher {
         mut request: DispatchRequest,
     ) -> Result<DispatchResponse, DispatchError> {
         self.attach_channel(&mut request).await;
-        self.ensure_artifact(&request).await?;
+        let ensured = self.ensure_artifact(&request).await?;
+        request.artifact = Some(self.sign_artifact(&ensured, &backend).await?);
         let job_id = create_id();
 
         match backend {
@@ -720,7 +765,8 @@ impl Dispatcher {
         mut request: DispatchRequest,
     ) -> Result<(DispatchResponse, ByteStream), DispatchError> {
         self.attach_channel(&mut request).await;
-        self.ensure_artifact(&request).await?;
+        let ensured = self.ensure_artifact(&request).await?;
+        request.artifact = Some(self.sign_artifact(&ensured, &self.config.backend).await?);
         let job_id = create_id();
 
         match self.config.backend {
@@ -782,7 +828,11 @@ impl Dispatcher {
         mut request: DispatchRequest,
     ) -> Result<(DispatchResponse, reqwest::Response), DispatchError> {
         self.attach_channel(&mut request).await;
-        self.ensure_artifact(&request).await?;
+        let ensured = self.ensure_artifact(&request).await?;
+        request.artifact = Some(
+            self.sign_artifact(&ensured, &ExecutionBackend::Http)
+                .await?,
+        );
         let url =
             self.config.executor_url.as_ref().ok_or_else(|| {
                 DispatchError::Configuration("EXECUTOR_URL not configured".into())
@@ -1538,6 +1588,7 @@ fn build_executor_payload(job_id: &str, request: &DispatchRequest) -> serde_json
         wasm_packages: request.wasm_packages.clone(),
         channel: request.channel.clone(),
         shadow: request.shadow,
+        artifact: request.artifact.clone(),
     };
 
     serde_json::to_value(&payload).expect("Failed to serialize DispatchPayload")
@@ -3274,6 +3325,7 @@ mod tests {
             channel: None,
             trigger,
             shadow: false,
+            artifact: None,
         }
     }
 
@@ -3316,22 +3368,79 @@ mod tests {
         assert_eq!(request.channel.map(|c| c.expires_at), Some(mine.expires_at));
     }
 
+    fn ensured_for_test() -> EnsuredArtifact {
+        EnsuredArtifact {
+            path: StorePath::from("tmp/apps/app-1/compiled/drafts/board-1/etag-1_fp.flcb"),
+            source_etag: Some("etag-1".into()),
+            registry_fingerprint: [7; 32],
+        }
+    }
+
     #[tokio::test]
-    async fn exact_etag_artifact_failure_blocks_only_the_exact_page_run() {
-        let failing_ensurer: ArtifactEnsurer = Arc::new(|_, _, _, _| {
+    async fn the_signed_artifact_travels_in_the_executor_payload() {
+        use flow_like_storage::object_store::{ObjectStore, PutPayload, memory::InMemory};
+
+        let ensured = ensured_for_test();
+        let store = Arc::new(InMemory::new());
+        store
+            .put(&ensured.path, PutPayload::from_static(b"flcb"))
+            .await
+            .expect("staged artifact");
+        let dispatcher = Dispatcher::new(
+            DispatchConfig::default(),
+            Some(Arc::new(FlowLikeStore::Memory(store))),
+        )
+        .await;
+
+        let artifact = dispatcher
+            .sign_artifact(&ensured, &ExecutionBackend::Http)
+            .await
+            .expect("signing needs only the staging store");
+        assert_eq!(artifact.path, ensured.path.to_string());
+        assert_eq!(artifact.source_etag.as_deref(), Some("etag-1"));
+        assert_eq!(
+            artifact.registry_fingerprint,
+            blake3::Hash::from_bytes([7; 32]).to_hex().to_string()
+        );
+        assert!(!artifact.url.is_empty());
+
+        let mut request = dispatch_request(DispatchTrigger::User);
+        request.artifact = Some(artifact.clone());
+        let payload = build_executor_payload("job-1", &request);
+        assert_eq!(payload["artifact"]["path"], artifact.path);
+        assert_eq!(payload["artifact"]["source_etag"], "etag-1");
+
+        let bare = build_executor_payload("job-1", &dispatch_request(DispatchTrigger::User));
+        assert!(
+            bare.get("artifact").is_none(),
+            "an unsigned request serialises without the field, which the executor rejects"
+        );
+    }
+
+    #[tokio::test]
+    async fn artifact_failure_blocks_every_run() {
+        let failing_ensurer: ArtifactEnsurer = Arc::new(|_, _, _, _, _| {
             Box::pin(async { Err(flow_like_types::anyhow!("artifact unavailable")) })
         });
 
-        let exact_dispatcher = Dispatcher::from_config(DispatchConfig::default());
+        // No assurer installed: nothing can be dispatched, Page run or not.
+        let bare_dispatcher = Dispatcher::from_config(DispatchConfig::default());
         let mut exact_without_ensurer = dispatch_request(DispatchTrigger::User);
         exact_without_ensurer.board_etag = Some("etag-1".into());
         assert!(matches!(
-            exact_dispatcher
+            bare_dispatcher
                 .ensure_artifact(&exact_without_ensurer)
                 .await,
             Err(DispatchError::Artifact(_))
         ));
+        assert!(matches!(
+            bare_dispatcher
+                .ensure_artifact(&dispatch_request(DispatchTrigger::User))
+                .await,
+            Err(DispatchError::Artifact(_))
+        ));
 
+        let exact_dispatcher = Dispatcher::from_config(DispatchConfig::default());
         exact_dispatcher.set_artifact_ensurer(failing_ensurer.clone());
         let mut exact = dispatch_request(DispatchTrigger::User);
         exact.board_etag = Some("etag-1".into());
@@ -3340,13 +3449,14 @@ mod tests {
             Err(DispatchError::Artifact(_))
         ));
 
+        // Ordinary runs no longer have an executor-side compile to fall back to.
         let ordinary_dispatcher = Dispatcher::from_config(DispatchConfig::default());
         ordinary_dispatcher.set_artifact_ensurer(failing_ensurer);
         let ordinary = dispatch_request(DispatchTrigger::User);
-        ordinary_dispatcher
-            .ensure_artifact(&ordinary)
-            .await
-            .expect("ordinary runs retain their in-memory fallback");
+        assert!(matches!(
+            ordinary_dispatcher.ensure_artifact(&ordinary).await,
+            Err(DispatchError::Artifact(_))
+        ));
 
         let dispatcher = Dispatcher::from_config(DispatchConfig::default());
         let mut reserved = dispatch_request(DispatchTrigger::User);

--- a/packages/api/src/execution/mod.rs
+++ b/packages/api/src/execution/mod.rs
@@ -6,6 +6,7 @@
 mod channel_jwt;
 pub mod compiled_artifacts;
 mod dispatch;
+pub mod wasm_node_stubs;
 mod jwt;
 mod page_action_jwt;
 mod page_action_sealer;

--- a/packages/api/src/execution/regression/mod.rs
+++ b/packages/api/src/execution/regression/mod.rs
@@ -979,6 +979,7 @@ async fn dispatch_case(
         channel: None,
         trigger: DispatchTrigger::System,
         shadow: true,
+        artifact: None,
     };
 
     let db_arc = Arc::new(state.db.clone());

--- a/packages/api/src/execution/wasm_node_stubs.rs
+++ b/packages/api/src/execution/wasm_node_stubs.rs
@@ -1,0 +1,106 @@
+//! Compile-only stand-ins for WASM nodes.
+//!
+//! Compiling a board needs each node's `Node` definition — pins, defaults,
+//! permissions — and nothing else; the registry fingerprint that binds an
+//! artifact to a node catalog hashes those definitions alone. For WASM nodes
+//! the API already holds them: the compiler workload instantiates each
+//! uploaded module in its own sandbox, calls its `get_nodes` export, and
+//! reports the result back, which the compilation callback stores in
+//! `wasm_package_version.nodes`. Reading that row is the API's entire contact
+//! with a WASM package — it never loads module bytes, so a sandbox escape in
+//! user WASM cannot reach API credentials. The logic here exists only to fill
+//! the registry's `(Node, NodeLogic)` shape and refuses to run.
+//!
+//! The row is only as good as the callback that wrote it, but a wrong row
+//! cannot make a wrong artifact run: the executor derives its nodes from the
+//! real module and rejects any artifact whose fingerprint disagrees.
+
+use flow_like::flow::execution::context::ExecutionContext;
+use flow_like::flow::node::{Node, NodeLogic};
+use flow_like_types::{anyhow, async_trait};
+
+pub struct WasmNodeStub {
+    node: Node,
+}
+
+impl WasmNodeStub {
+    pub fn new(node: Node) -> Self {
+        Self { node }
+    }
+}
+
+#[async_trait]
+impl NodeLogic for WasmNodeStub {
+    fn get_node(&self) -> Node {
+        self.node.clone()
+    }
+
+    async fn run(&self, _context: &mut ExecutionContext) -> flow_like_types::Result<()> {
+        Err(anyhow!(
+            "WASM node '{}' is compile-only in the API and never executes here",
+            self.node.name
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flow_like::flow::node::NodeWasm;
+    use flow_like::state::FlowNodeRegistryInner;
+    use std::sync::Arc;
+
+    fn wasm_node(name: &str) -> Node {
+        let mut node = Node::new(name, name, "a package node", "Package");
+        node.wasm = Some(NodeWasm {
+            package_id: "com.example.pkg".into(),
+            permissions: Vec::new(),
+        });
+        node
+    }
+
+    /// The whole security argument rests on this: the crate that compiles
+    /// user boards must not be able to load user WASM at all.
+    #[test]
+    fn the_api_never_links_the_wasm_runtime_outside_tests() {
+        let manifest = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"))
+            .expect("Cargo.toml is readable");
+        let dependencies = manifest
+            .split("[dev-dependencies]")
+            .next()
+            .expect("manifest has a dependencies section");
+        assert!(
+            !dependencies.contains("flow-like-wasm.workspace")
+                && !dependencies.contains("flow-like-wasm ="),
+            "flow-like-wasm must stay a dev-dependency of the API"
+        );
+    }
+
+    #[test]
+    fn stubbed_wasm_nodes_change_the_fingerprint_deterministically() {
+        let base = FlowNodeRegistryInner::new(0);
+        let base_fingerprint = base.fingerprint();
+
+        let build = || {
+            let mut overlay = base.clone();
+            let node = wasm_node("pkg_node");
+            overlay.insert(node.clone(), Arc::new(WasmNodeStub::new(node)));
+            overlay.fingerprint()
+        };
+        let first = build();
+        let second = build();
+
+        assert_ne!(first, base_fingerprint, "a WASM node must be part of the identity");
+        assert_eq!(first, second, "the same node set must always hash the same");
+    }
+
+    #[tokio::test]
+    async fn a_stub_refuses_to_run() {
+        let node = wasm_node("pkg_node");
+        let stub = WasmNodeStub::new(node.clone());
+        assert_eq!(stub.get_node().name, node.name);
+        // `run` needs an ExecutionContext; the refusal is exercised through the
+        // registry in `compiled_artifacts` — here we only pin the contract that
+        // the stub yields the node it was built from.
+    }
+}

--- a/packages/api/src/lib.rs
+++ b/packages/api/src/lib.rs
@@ -92,13 +92,14 @@ pub fn construct_router(state: Arc<State>) -> Router {
 /// policy is not acceptable. Keeping CORS inside every nested route layer
 /// prevents an inner wildcard response from bypassing a stricter outer layer.
 pub fn construct_router_with_cors(state: Arc<State>, cors: CorsLayer) -> Router {
-    // Executors are read-only on the meta store; guarantee compiled board
-    // artifacts exist before every dispatch. Installed here because the
+    // Executors hold no meta-store credential and obtain their board only as
+    // the presigned compiled artifact the dispatcher hands them, so the
+    // artifact must exist before every dispatch. Installed here because the
     // dispatcher is built before the state it needs exists.
     {
         let ensurer_state = state.clone();
         state.dispatcher.set_artifact_ensurer(std::sync::Arc::new(
-            move |app_id, board_id, version, board_etag| {
+            move |app_id, board_id, version, board_etag, wasm_packages| {
                 let state = ensurer_state.clone();
                 Box::pin(async move {
                     crate::execution::compiled_artifacts::ensure_compiled_artifact(
@@ -107,6 +108,7 @@ pub fn construct_router_with_cors(state: Arc<State>, cors: CorsLayer) -> Router 
                         &board_id,
                         version,
                         board_etag.as_deref(),
+                        wasm_packages.as_ref(),
                     )
                     .await
                 })

--- a/packages/api/src/routes/app/board/invoke_board.rs
+++ b/packages/api/src/routes/app/board/invoke_board.rs
@@ -369,6 +369,7 @@ pub async fn invoke_board(
         channel: None,
         trigger: DispatchTrigger::User,
         shadow: false,
+        artifact: None,
     };
 
     // For isolated K8s jobs, insert run record and dispatch async

--- a/packages/api/src/routes/app/board/invoke_board_async.rs
+++ b/packages/api/src/routes/app/board/invoke_board_async.rs
@@ -313,6 +313,7 @@ pub async fn invoke_board_async(
         channel: None,
         trigger: DispatchTrigger::User,
         shadow: false,
+        artifact: None,
     };
 
     let response = state

--- a/packages/api/src/routes/app/board/version_board.rs
+++ b/packages/api/src/routes/app/board/version_board.rs
@@ -106,7 +106,7 @@ pub async fn version_board(
             );
         }
     }
-    spawn_compiled_artifact_warmup(&board, published);
+    spawn_compiled_artifact_warmup(&state, &app_id, &board, published);
     // Publish-triggered regression suites: one indexed projection lookup plus
     // the dispatches, all on a detached task — the publish PATCH is never
     // blocked or failed by them.
@@ -179,21 +179,28 @@ async fn published_page_prerun_manifests(
 }
 
 /// Eagerly compile the just-published immutable snapshot so the executor's
-/// first run of this version can start from an artifact instead of the proto.
+/// first run of this version finds its artifact already there.
 ///
 /// Board and Page prerun manifests are persisted synchronously before this
 /// best-effort task starts because a Lambda may freeze as soon as the response
-/// is returned. Boards containing WASM nodes skip the compile: their
-/// `on_update` runs against a per-request bundle registry only the executor
-/// has, so its lazy compile is authoritative there.
-fn spawn_compiled_artifact_warmup(board: &Board, published: (u32, u32, u32)) {
+/// is returned. The pre-dispatch assurance recompiles on a miss or a registry
+/// mismatch, so this is warmth, never correctness. It compiles against the
+/// registry the dispatch would use — the built-in catalog extended with the
+/// app's WASM node definitions — so the fingerprint matches on first run.
+fn spawn_compiled_artifact_warmup(
+    state: &AppState,
+    app_id: &str,
+    board: &Board,
+    published: (u32, u32, u32),
+) {
     let Some(app_state) = board.app_state.clone() else {
         return;
     };
     let board_dir = board.board_dir.clone();
     let board_id = board.id.clone();
+    let state = state.clone();
+    let app_id = app_id.to_string();
 
-    let has_wasm = board.has_wasm_nodes();
     let mut snapshot = board.clone();
     snapshot.version = published;
 
@@ -206,11 +213,16 @@ fn spawn_compiled_artifact_warmup(board: &Board, published: (u32, u32, u32)) {
             return;
         };
         let store = store.as_generic();
-        if has_wasm {
-            return;
-        }
 
-        let registry = app_state.node_registry.read().await.node_registry.clone();
+        let wasm_packages =
+            crate::execution::wasm_resolve::resolve_wasm_packages(&state, &app_id).await;
+        let registry = match state.artifact_registry(wasm_packages.as_ref()).await {
+            Ok(registry) => registry,
+            Err(e) => {
+                tracing::warn!(board_id = %board_id, error = %e, "Compiled-board warm-up: registry unavailable");
+                return;
+            }
+        };
         let fingerprint = registry.fingerprint();
         let compiled = match flow_like::flow::compiled::compile::compile_board_with_catalog(
             &snapshot,

--- a/packages/api/src/routes/app/events/invoke_event.rs
+++ b/packages/api/src/routes/app/events/invoke_event.rs
@@ -736,6 +736,7 @@ async fn invoke_event_impl(
         channel: None,
         trigger: DispatchTrigger::User,
         shadow: false,
+        artifact: None,
     };
 
     // For isolated K8s jobs, insert run record and dispatch async

--- a/packages/api/src/routes/app/events/invoke_event_async.rs
+++ b/packages/api/src/routes/app/events/invoke_event_async.rs
@@ -615,6 +615,7 @@ pub async fn invoke_event_async(
         channel: None,
         trigger: DispatchTrigger::User,
         shadow: false,
+        artifact: None,
     };
 
     // No executor can observe this run before dispatch. Insert only after all

--- a/packages/api/src/routes/app/events/setup_event.rs
+++ b/packages/api/src/routes/app/events/setup_event.rs
@@ -482,6 +482,7 @@ pub(crate) async fn run_event_setup(
         // A background setup workflow emitting config.
         trigger: DispatchTrigger::System,
         shadow: false,
+        artifact: None,
     };
 
     let backend = state.dispatcher.backend();

--- a/packages/api/src/routes/app/wasm_catalog.rs
+++ b/packages/api/src/routes/app/wasm_catalog.rs
@@ -10,7 +10,7 @@ use flow_like::flow::{
     node::{Node, NodeWasm},
 };
 use flow_like_wasm_schema::manifest::PackageNodeEntry;
-use sea_orm::{ColumnTrait, Condition, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, Condition, DatabaseConnection, EntityTrait, QueryFilter};
 use std::sync::Arc;
 
 /// An app's WASM node catalog together with a token that changes whenever the catalog does.
@@ -105,36 +105,53 @@ async fn wasm_nodes_for_packages(
     state: &AppState,
     packages: &[app_package::Model],
 ) -> Result<Vec<Node>, ApiError> {
-    if packages.is_empty() {
+    let pins: Vec<(String, String)> = packages
+        .iter()
+        .map(|pkg| (pkg.package_id.clone(), pkg.version.clone()))
+        .collect();
+    wasm_nodes_for_pins(&state.db, &pins).await
+}
+
+/// The `Node` definitions of exactly these `(package_id, version)` pins, from
+/// the `nodes` column the compilation callback stored when the compiler
+/// workload ran the module's `get_nodes`. This is the API's only view of a WASM
+/// node: it never loads the module, and the definitions it rebuilds are
+/// fingerprint-identical to the ones the executor derives from the running
+/// module (see `both_node_builders_agree_on_every_fingerprint_input`), which is
+/// what lets the API compile boards the executor will accept.
+pub async fn wasm_nodes_for_pins(
+    db: &DatabaseConnection,
+    pins: &[(String, String)],
+) -> Result<Vec<Node>, ApiError> {
+    if pins.is_empty() {
         return Ok(Vec::new());
     }
 
     let mut pinned = Condition::any();
-    for pkg in packages {
+    for (package_id, version) in pins {
         pinned = pinned.add(
             Condition::all()
-                .add(wasm_package_version::Column::PackageId.eq(&pkg.package_id))
-                .add(wasm_package_version::Column::Version.eq(&pkg.version)),
+                .add(wasm_package_version::Column::PackageId.eq(package_id))
+                .add(wasm_package_version::Column::Version.eq(version)),
         );
     }
 
     let mut nodes_by_pin: HashMap<(String, String), serde_json::Value> =
         wasm_package_version::Entity::find()
             .filter(pinned)
-            .all(&state.db)
+            .all(db)
             .await?
             .into_iter()
             .map(|record| ((record.package_id, record.version), record.nodes))
             .collect();
 
-    let mut wasm_nodes: Vec<Node> = Vec::with_capacity(packages.len() * 5);
+    let mut wasm_nodes: Vec<Node> = Vec::with_capacity(pins.len() * 5);
 
-    for pkg in packages {
-        let key = (pkg.package_id.clone(), pkg.version.clone());
-        let Some(nodes_value) = nodes_by_pin.remove(&key) else {
+    for (package_id, version) in pins {
+        let Some(nodes_value) = nodes_by_pin.remove(&(package_id.clone(), version.clone())) else {
             tracing::warn!(
-                package_id = %pkg.package_id,
-                version = %pkg.version,
+                package_id = %package_id,
+                version = %version,
                 "app catalog: pinned WASM package version not found; skipping its nodes"
             );
             continue;
@@ -144,7 +161,7 @@ async fn wasm_nodes_for_packages(
             serde_json::from_value(nodes_value).unwrap_or_default();
 
         for entry in &entries {
-            wasm_nodes.push(package_node_to_node(entry, &pkg.package_id));
+            wasm_nodes.push(package_node_to_node(entry, package_id));
         }
     }
 

--- a/packages/api/src/routes/execution/mod.rs
+++ b/packages/api/src/routes/execution/mod.rs
@@ -13,12 +13,14 @@ use axum::{
 
 pub mod progress;
 pub mod public_key;
+pub mod widgets;
 
 pub fn routes() -> Router<AppState> {
     Router::new()
         // Executor endpoints (require executor JWT)
         .route("/progress", post(progress::report_progress))
         .route("/events", post(progress::push_events))
+        .route("/apps/{app_id}/widgets", get(widgets::get_app_widgets))
         // User endpoints (require user JWT)
         .route("/poll", get(progress::poll_status))
         // App-auth endpoints (require normal app access)

--- a/packages/api/src/routes/execution/progress.rs
+++ b/packages/api/src/routes/execution/progress.rs
@@ -935,7 +935,7 @@ fn page_event_message_id(event: &ExecutionEventInput, batch_index: usize) -> Str
         .unwrap_or_else(|| format!("batch-index:{batch_index}"))
 }
 
-fn extract_bearer_token(headers: &HeaderMap) -> Result<&str, ApiError> {
+pub(super) fn extract_bearer_token(headers: &HeaderMap) -> Result<&str, ApiError> {
     crate::middleware::jwt::viewer_authorization(headers)
         .ok_or_else(|| ApiError::bad_request("Missing Authorization header".to_string()))?
         .strip_prefix("Bearer ")

--- a/packages/api/src/routes/execution/widgets.rs
+++ b/packages/api/src/routes/execution/widgets.rs
@@ -1,0 +1,115 @@
+//! Executor → API: an app's declarative widgets.
+//!
+//! The `Instantiate Widget` node used to read `apps/{app}/manifest.app` and
+//! every `{widget}.widget` straight from the meta store — the one run-time read
+//! that kept a storage credential in the executor. Executors already prove
+//! their identity to this API with the executor JWT for progress reporting, so
+//! widgets travel the same way. The executor caches the response for the run.
+
+use crate::{
+    error::ApiError,
+    execution::{ExecutionClaims, verify_execution_jwt},
+    state::AppState,
+};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::{HeaderMap, HeaderValue, header},
+    response::IntoResponse,
+};
+use flow_like::a2ui::widget::Widget;
+use flow_like::app::App;
+
+/// Whether a run may read this app's widgets: its own app, or one it reached
+/// through an app connection — the signed `app_chain` records exactly those.
+fn executor_may_read_app(claims: &ExecutionClaims, app_id: &str) -> bool {
+    claims.app_id == app_id
+        || claims
+            .app_chain
+            .as_deref()
+            .is_some_and(|chain| chain.iter().any(|chained| chained == app_id))
+}
+
+/// Declarative widgets of an app, for the executor running one of its boards.
+#[utoipa::path(
+    get,
+    path = "/execution/apps/{app_id}/widgets",
+    tag = "execution",
+    description = "Declarative widgets of an app, served to the executor running one of its boards.",
+    params(("app_id" = String, Path, description = "Application ID")),
+    responses(
+        (status = 200, description = "The app's widgets", body = String, content_type = "application/json"),
+        (status = 400, description = "Invalid request or JWT"),
+        (status = 403, description = "The run is not bound to this app")
+    ),
+    security(("executor_jwt" = []))
+)]
+#[tracing::instrument(name = "GET /execution/apps/{app_id}/widgets", skip(state, headers))]
+pub async fn get_app_widgets(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(app_id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let token = super::progress::extract_bearer_token(&headers)?;
+    let claims = verify_execution_jwt(token).map_err(|e| {
+        tracing::warn!(error = %e, "Invalid execution JWT");
+        ApiError::bad_request(format!("Invalid execution JWT: {}", e))
+    })?;
+    if !executor_may_read_app(&claims, &app_id) {
+        return Err(ApiError::forbidden(
+            "execution is not bound to this app".to_string(),
+        ));
+    }
+
+    let app_state = state.master_state(&state).await?;
+    let app = App::load(app_id, app_state).await?;
+    let widgets: Vec<Widget> = app.get_widgets().await?;
+
+    Ok((
+        [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
+        Json(widgets),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend_jwt::TokenType;
+
+    fn claims(app_id: &str, chain: Option<Vec<&str>>) -> ExecutionClaims {
+        ExecutionClaims {
+            sub: "user-1".into(),
+            technical_user_id: None,
+            run_id: "run-1".into(),
+            app_id: app_id.into(),
+            board_id: "board-1".into(),
+            event_id: None,
+            app_chain: chain.map(|c| c.into_iter().map(String::from).collect()),
+            correlation: None,
+            page_execution: None,
+            shadow: None,
+            callback_url: "https://api.test".into(),
+            token_type: TokenType::Executor,
+            iss: "flow-like".into(),
+            aud: "flow-like-executor".into(),
+            iat: 0,
+            nbf: 0,
+            exp: 0,
+            jti: "jti-1".into(),
+        }
+    }
+
+    #[test]
+    fn a_run_reads_its_own_app_and_the_apps_it_was_chained_through_only() {
+        assert!(executor_may_read_app(&claims("app-1", None), "app-1"));
+        assert!(executor_may_read_app(
+            &claims("app-2", Some(vec!["app-1", "app-2"])),
+            "app-1"
+        ));
+        assert!(!executor_may_read_app(&claims("app-1", None), "app-9"));
+        assert!(!executor_may_read_app(
+            &claims("app-2", Some(vec!["app-1"])),
+            "app-9"
+        ));
+    }
+}

--- a/packages/api/src/routes/inbound.rs
+++ b/packages/api/src/routes/inbound.rs
@@ -2281,6 +2281,7 @@ async fn dispatch_event_collect(
         // An external REST/MCP caller, not a Flow-Like client.
         trigger: DispatchTrigger::System,
         shadow: false,
+        artifact: None,
     };
 
     let now = chrono::Utc::now().naive_utc();

--- a/packages/api/src/routes/sink/trigger.rs
+++ b/packages/api/src/routes/sink/trigger.rs
@@ -788,6 +788,7 @@ pub async fn trigger_event(
         // Programmatic trigger: cron workers, Lambda handlers, queue processors.
         trigger: DispatchTrigger::System,
         shadow: false,
+        artifact: None,
     };
 
     // Create run record
@@ -1109,6 +1110,7 @@ pub async fn trigger_http(
         // Inbound webhook.
         trigger: DispatchTrigger::System,
         shadow: false,
+        artifact: None,
     };
 
     // Create run record
@@ -1526,6 +1528,7 @@ pub async fn trigger_telegram(
         // Telegram bot service.
         trigger: DispatchTrigger::System,
         shadow: false,
+        artifact: None,
     };
 
     // Create run record
@@ -1878,6 +1881,7 @@ pub async fn trigger_discord(
         // Discord bot service.
         trigger: DispatchTrigger::System,
         shadow: false,
+        artifact: None,
     };
 
     // Create run record

--- a/packages/api/src/state.rs
+++ b/packages/api/src/state.rs
@@ -14,7 +14,8 @@ use flow_like_secrets::{
     EnvProviderConfig, ExposeSecret, ProviderConfig, SecretRef, SecretStore, SecretStoreConfig,
 };
 use flow_like_types::bail;
-use flow_like_types::{Result, Value};
+use flow_like_types::dispatch::WasmPackageRef;
+use flow_like_types::{Result, Value, anyhow};
 use hyper_util::{
     client::legacy::{Client, connect::HttpConnector},
     rt::TokioExecutor,
@@ -401,6 +402,11 @@ pub struct State {
     /// content-addressed. ETag-bound dispatches revalidate object existence
     /// because lifecycle cleanup can remove an artifact before this entry.
     pub compiled_artifact_cache: moka::sync::Cache<String, ()>,
+    /// Registries compiled artifacts are fingerprinted against, one per
+    /// resolved WASM package set (`wasm_package_set_revision`): the built-in
+    /// catalog extended with the packages' manifest `Node`s. See
+    /// [`State::artifact_registry`].
+    pub artifact_registries: moka::sync::Cache<String, Arc<FlowNodeRegistryInner>>,
     /// Prerun manifests keyed by (app, board, version|etag). Content-addressed
     /// like `compiled_artifact_cache`, so entries never go stale.
     pub prerun_manifest_cache:
@@ -442,6 +448,47 @@ pub struct State {
 }
 
 impl State {
+    /// The registry a compiled artifact is fingerprinted against.
+    ///
+    /// The built-in catalog alone when the run brings no WASM packages;
+    /// otherwise the catalog extended with the `Node` definitions of exactly
+    /// the resolved packages — the same set the executor overlays from the
+    /// loaded modules, so both sides compute one fingerprint and the artifact
+    /// the API writes is the one the executor accepts. Built from the node
+    /// definitions the compiler workload reported at upload time
+    /// (`wasm_package_version.nodes`): no module bytes are read here, and the
+    /// stand-in logic refuses to run, so user WASM never executes in this
+    /// process.
+    pub async fn artifact_registry(
+        &self,
+        wasm_packages: Option<&HashMap<String, WasmPackageRef>>,
+    ) -> Result<Arc<FlowNodeRegistryInner>> {
+        let Some(packages) = wasm_packages.filter(|packages| !packages.is_empty()) else {
+            return Ok(self.registry.clone());
+        };
+        let key = flow_like_types::dispatch::wasm_package_set_revision(Some(packages));
+        if let Some(registry) = self.artifact_registries.get(&key) {
+            return Ok(registry);
+        }
+
+        let pins: Vec<(String, String)> = packages
+            .iter()
+            .map(|(package_id, package)| (package_id.clone(), package.version.clone()))
+            .collect();
+        let nodes = crate::routes::app::wasm_catalog::wasm_nodes_for_pins(&self.db, &pins)
+            .await
+            .map_err(|e| anyhow!("failed to load WASM node manifests for compilation: {e}"))?;
+
+        let mut overlay = (*self.registry).clone();
+        for node in nodes {
+            let logic = crate::execution::wasm_node_stubs::WasmNodeStub::new(node.clone());
+            overlay.insert(node, Arc::new(logic));
+        }
+        let overlay = Arc::new(overlay);
+        self.artifact_registries.insert(key, overlay.clone());
+        Ok(overlay)
+    }
+
     fn board_mutation_lock(
         &self,
         app_id: &str,
@@ -882,6 +929,10 @@ impl State {
             compiled_artifact_cache: moka::sync::Cache::builder()
                 .max_capacity(16_384)
                 .time_to_idle(Duration::from_secs(12 * 60 * 60))
+                .build(),
+            artifact_registries: moka::sync::Cache::builder()
+                .max_capacity(256)
+                .time_to_idle(Duration::from_secs(60 * 60))
                 .build(),
             prerun_manifest_cache: moka::sync::Cache::builder()
                 .max_capacity(4_096)

--- a/packages/catalog/std/src/a2ui/instantiate_widget.rs
+++ b/packages/catalog/std/src/a2ui/instantiate_widget.rs
@@ -6,7 +6,6 @@ use flow_like::a2ui::micro_widget::{
     self, MICRO_WIDGET_COMPONENT_TYPE, ResolvedWidget, WidgetProvider,
 };
 use flow_like::a2ui::widget::{CustomizationType, ExposedPropType, Widget};
-use flow_like::app::App;
 use flow_like::flow::{
     board::Board,
     execution::context::ExecutionContext,
@@ -660,8 +659,10 @@ impl NodeLogic for InstantiateWidget {
                 .await;
         }
 
-        let app = App::load(app_id.clone(), context.app_state.clone()).await?;
-        let widgets = app.get_widgets().await.unwrap_or_default();
+        // Through the host's widget source — on a server executor that is the
+        // hub API, cached for the run, so a board that instantiates the same
+        // widget N times still costs one fetch and never touches the meta store.
+        let widgets = micro_widget::load_app_widgets(&app_id, context.app_state.clone()).await?;
         let widget = find_widget_by_selector(&widgets, &widget_selector)
             .ok_or_else(|| flow_like_types::anyhow!("Widget '{}' not found", widget_selector))?;
         let widget_id = widget.id.clone();

--- a/packages/core/src/a2ui/micro_widget.rs
+++ b/packages/core/src/a2ui/micro_widget.rs
@@ -218,6 +218,31 @@ pub trait PackageWidgetSource: Send + Sync {
     ) -> flow_like_types::Result<Vec<PackageWidgetRef>>;
 }
 
+/// Host-registered supplier of an app's declarative widgets.
+///
+/// Server executors implement this over the hub API so a run never needs a
+/// meta-store credential to instantiate a widget; the desktop leaves it
+/// unregistered and [`load_app_widgets`] falls back to the local store.
+/// Implementations cache per instance, so after the first call every further
+/// instantiation in the same run costs no I/O.
+#[async_trait]
+pub trait AppWidgetSource: Send + Sync {
+    async fn list_app_widgets(&self, app_id: &str) -> flow_like_types::Result<Arc<Vec<Widget>>>;
+}
+
+/// An app's declarative widgets, through the registered [`AppWidgetSource`]
+/// when there is one and from the meta store otherwise.
+pub async fn load_app_widgets(
+    app_id: &str,
+    state: Arc<FlowLikeState>,
+) -> flow_like_types::Result<Arc<Vec<Widget>>> {
+    if let Some(source) = state.app_widget_source().await {
+        return source.list_app_widgets(app_id).await;
+    }
+    let app = App::load(app_id.to_string(), state).await?;
+    Ok(Arc::new(app.get_widgets().await?))
+}
+
 /// A widget resolved through the unified provider.
 pub enum ResolvedWidget<'a> {
     Declarative(&'a Widget),
@@ -248,11 +273,20 @@ impl WidgetProvider {
     /// tolerated (empty list, matching existing behavior); package source
     /// errors propagate so callers can surface them.
     pub async fn load(app_id: &str, state: Arc<FlowLikeState>) -> flow_like_types::Result<Self> {
-        let app = App::load(app_id.to_string(), state.clone()).await?;
-        let declarative = app.get_widgets().await.unwrap_or_default();
+        let declarative = load_app_widgets(app_id, state.clone())
+            .await
+            .map(|widgets| widgets.as_ref().clone())
+            .unwrap_or_default();
         let package_widgets = match state.package_widget_source().await {
-            Some(source) if !app.packages.is_empty() => source.list_widgets(&app.packages).await?,
-            _ => Vec::new(),
+            Some(source) => {
+                let app = App::load(app_id.to_string(), state.clone()).await?;
+                if app.packages.is_empty() {
+                    Vec::new()
+                } else {
+                    source.list_widgets(&app.packages).await?
+                }
+            }
+            None => Vec::new(),
         };
         Ok(Self {
             declarative,
@@ -437,5 +471,63 @@ mod tests {
         ));
         assert!(provider.resolve("pkg:unknown/none").is_none());
         assert!(provider.resolve("missing").is_none());
+    }
+}
+
+#[cfg(test)]
+mod app_widget_source_tests {
+    use super::*;
+    use crate::state::FlowLikeConfig;
+    use flow_like_storage::files::store::FlowLikeStore;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingSource {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl AppWidgetSource for CountingSource {
+        async fn list_app_widgets(
+            &self,
+            _app_id: &str,
+        ) -> flow_like_types::Result<Arc<Vec<Widget>>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Arc::new(Vec::new()))
+        }
+    }
+
+    fn state() -> Arc<FlowLikeState> {
+        let store = FlowLikeStore::Memory(Arc::new(
+            flow_like_storage::object_store::memory::InMemory::new(),
+        ));
+        Arc::new(FlowLikeState::new(
+            FlowLikeConfig::with_default_store(store),
+            crate::utils::http::HTTPClient::new_without_refetch(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn a_registered_source_replaces_the_store_read() {
+        let state = state();
+        let source = Arc::new(CountingSource {
+            calls: AtomicUsize::new(0),
+        });
+        state.register_app_widget_source(source.clone()).await;
+
+        load_app_widgets("app-1", state.clone()).await.expect("served by the source");
+        load_app_widgets("app-1", state.clone()).await.expect("served by the source");
+        assert_eq!(
+            source.calls.load(Ordering::SeqCst),
+            2,
+            "the shared helper delegates every call; per-run caching is the source's job"
+        );
+    }
+
+    #[tokio::test]
+    async fn without_a_source_the_store_is_consulted() {
+        // Nothing registered and an empty store: the fallback path runs and fails
+        // on the missing manifest instead of pretending the app has no widgets.
+        let state = state();
+        assert!(load_app_widgets("app-1", state).await.is_err());
     }
 }

--- a/packages/core/src/flow/compiled/mod.rs
+++ b/packages/core/src/flow/compiled/mod.rs
@@ -38,7 +38,7 @@ pub use prerun::{
     decode_manifest, draft_manifest_path, draft_page_manifest_path, encode_manifest,
     legacy_manifest_path, manifest_path, version_page_manifest_path,
 };
-pub use resolver::{TemplateCache, persist_artifact};
+pub use resolver::{TemplateCache, persist_artifact, template_from_bytes};
 pub use template::CompiledRunTemplate;
 
 use flow_like_storage::Path;

--- a/packages/core/src/flow/compiled/resolver.rs
+++ b/packages/core/src/flow/compiled/resolver.rs
@@ -1,9 +1,14 @@
-//! Shared template resolution: in-process cache → persisted artifact →
-//! compile-from-source with background write-back.
+//! Shared template resolution.
 //!
-//! Both the cloud executor and the desktop runtime resolve boards through
-//! this type; they differ only in cache instance and extra cache-key salt
-//! (the executor keys on its per-request WASM bundle signature).
+//! Two entry points share one cache type:
+//! - [`TemplateCache::resolve`] — the desktop path: in-process cache →
+//!   persisted artifact → compile-from-source with background write-back.
+//!   It addresses the meta store directly.
+//! - [`template_from_bytes`] + [`TemplateCache::get`]/[`TemplateCache::insert`]
+//!   — the server-executor path. The API compiles every run ahead of dispatch
+//!   and hands the executor a presigned GET for the exact `.flcb`; the
+//!   executor decodes those bytes and never touches the meta store, never
+//!   reads a board proto and never writes an artifact back.
 
 use super::CompiledRunTemplate;
 use crate::flow::board::Board;
@@ -61,7 +66,47 @@ impl TemplateCache {
         }
     }
 
-    /// Resolve a board into a shared run template.
+    /// The cache key for one (board, content identity, registry, salt) tuple.
+    ///
+    /// `version_key` is `M_m_p` for a pinned version, `latest@{etag}` for a
+    /// floating board pinned to a source ETag, or `latest` when only HEAD
+    /// revalidation identifies it. `key_salt` segments the cache beyond
+    /// app/board/version — the executor passes its WASM bundle signature.
+    pub fn cache_key(
+        app_id: &str,
+        board_id: &str,
+        version_key: &str,
+        fingerprint: &[u8; 32],
+        key_salt: &str,
+    ) -> String {
+        let fingerprint_hex = blake3::Hash::from_bytes(*fingerprint).to_hex();
+        format!(
+            "{app_id}:{board_id}:{version_key}:{}:{key_salt}",
+            &fingerprint_hex.as_str()[..16]
+        )
+    }
+
+    /// A cached template by exact key, without revalidation. Callers that key
+    /// on a content identity (source ETag or pinned version) need none.
+    pub fn get(&self, key: &str) -> Option<Arc<CompiledRunTemplate>> {
+        self.inner.get(key).map(|cached| cached.template.clone())
+    }
+
+    /// Cache a template the caller built itself. Entries carry no storage
+    /// identity because only [`Self::resolve`] revalidates by HEAD, and it
+    /// only ever revalidates keys it computed itself.
+    pub fn insert(&self, key: String, template: Arc<CompiledRunTemplate>) {
+        self.inner.insert(
+            key,
+            Arc::new(CachedTemplate {
+                template,
+                e_tag: None,
+                last_modified: chrono::Utc::now(),
+            }),
+        );
+    }
+
+    /// Resolve a board into a shared run template (desktop path).
     ///
     /// Warm path: this cache (HEAD-revalidated for "latest"). Cold path: the
     /// persisted artifact (`compiled/` for versions, app-scoped
@@ -70,8 +115,7 @@ impl TemplateCache {
     /// last resort: load the proto, run `node_updates`, compile, and persist
     /// the artifact in the background.
     ///
-    /// `key_salt` lets callers segment the cache beyond app/board/version —
-    /// the executor passes its WASM bundle signature.
+    /// `key_salt` lets callers segment the cache beyond app/board/version.
     pub async fn resolve(
         &self,
         state: &Arc<FlowLikeState>,
@@ -114,11 +158,7 @@ impl TemplateCache {
             (None, Some(etag)) => format!("latest@{etag}"),
             (None, None) => "latest".to_string(),
         };
-        let fingerprint_hex = blake3::Hash::from_bytes(fingerprint).to_hex();
-        let cache_key = format!(
-            "{app_id}:{board_id}:{version_key}:{}:{key_salt}",
-            &fingerprint_hex.as_str()[..16]
-        );
+        let cache_key = Self::cache_key(app_id, board_id, &version_key, &fingerprint, key_salt);
 
         let mut source_head: Option<ObjectMeta> = None;
         if let Some(cached) = self.inner.get(&cache_key) {
@@ -274,20 +314,44 @@ async fn template_from_artifact(
 ) -> Option<Arc<CompiledRunTemplate>> {
     let result = meta_store.get(artifact_path).await.ok()?;
     let bytes = result.bytes().await.ok()?;
-    let compiled_board = match super::decode_artifact(&bytes, Some(fingerprint)) {
-        Ok(compiled_board) => compiled_board,
+    match template_from_bytes(&bytes, fingerprint, registry, storage_root) {
+        Ok(template) => Some(template),
         Err(e) => {
             tracing::debug!(path = %artifact_path, error = %e, "Compiled artifact rejected");
-            return None;
-        }
-    };
-    match CompiledRunTemplate::from_compiled(&compiled_board, registry, storage_root.clone()) {
-        Ok(template) => Some(Arc::new(template)),
-        Err(e) => {
-            tracing::warn!(path = %artifact_path, error = %e, "Compiled artifact failed template build");
             None
         }
     }
+}
+
+/// Build a run template from the bytes of a persisted `.flcb` artifact.
+///
+/// This is the whole of the server executor's board loading: the API
+/// compiled these bytes against a registry whose fingerprint is in the
+/// header, and the executor accepts them only if that fingerprint is its
+/// own — an artifact compiled against a different node catalog would bake
+/// the wrong defaults and pin layouts. The error names both fingerprints so
+/// a deploy skew between API and executor is diagnosable from the message.
+pub fn template_from_bytes(
+    bytes: &[u8],
+    fingerprint: &[u8; 32],
+    registry: &FlowNodeRegistryInner,
+    storage_root: &Path,
+) -> Result<Arc<CompiledRunTemplate>> {
+    let header = super::peek_header(bytes)?;
+    if &header.registry_fingerprint != fingerprint {
+        let ours = blake3::Hash::from_bytes(*fingerprint).to_hex();
+        let theirs = blake3::Hash::from_bytes(header.registry_fingerprint).to_hex();
+        return Err(anyhow!(
+            "compiled artifact was built against registry {} but this runtime's registry is {}",
+            &theirs.as_str()[..16],
+            &ours.as_str()[..16]
+        ));
+    }
+    let compiled_board = super::decode_artifact(bytes, Some(fingerprint))?;
+    let template =
+        CompiledRunTemplate::from_compiled(&compiled_board, registry, storage_root.clone())
+            .map_err(|e| anyhow!("compiled artifact failed template build: {e}"))?;
+    Ok(Arc::new(template))
 }
 
 /// Persist a compiled artifact in the background. Artifacts are recreatable,

--- a/packages/core/src/state.rs
+++ b/packages/core/src/state.rs
@@ -505,6 +505,12 @@ pub struct FlowLikeState {
     pub package_widget_source:
         Arc<RwLock<Option<Arc<dyn crate::a2ui::micro_widget::PackageWidgetSource>>>>,
 
+    /// Host-registered source of an app's declarative widgets (see
+    /// `a2ui::micro_widget::load_app_widgets`). Server executors register a
+    /// hub-API client here so runs never read widgets from the meta store.
+    pub app_widget_source:
+        Arc<RwLock<Option<Arc<dyn crate::a2ui::micro_widget::AppWidgetSource>>>>,
+
     /// Where this state's process runs. Server-side entry points set
     /// [`ExecutionEnvironment::Server`] so process-level services without a
     /// run context (the model factory) can refuse ambient host credentials.
@@ -557,6 +563,7 @@ impl FlowLikeState {
             page_registry: Arc::new(DashMap::new()),
 
             package_widget_source: Arc::new(RwLock::new(None)),
+            app_widget_source: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -594,6 +601,7 @@ impl FlowLikeState {
             page_registry: Arc::new(DashMap::new()),
 
             package_widget_source: Arc::new(RwLock::new(None)),
+            app_widget_source: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -610,6 +618,21 @@ impl FlowLikeState {
         &self,
     ) -> Option<Arc<dyn crate::a2ui::micro_widget::PackageWidgetSource>> {
         self.package_widget_source.read().await.clone()
+    }
+
+    /// Register the host implementation supplying an app's declarative widgets.
+    pub async fn register_app_widget_source(
+        &self,
+        source: Arc<dyn crate::a2ui::micro_widget::AppWidgetSource>,
+    ) {
+        let mut guard = self.app_widget_source.write().await;
+        *guard = Some(source);
+    }
+
+    pub async fn app_widget_source(
+        &self,
+    ) -> Option<Arc<dyn crate::a2ui::micro_widget::AppWidgetSource>> {
+        self.app_widget_source.read().await.clone()
     }
 
     #[cfg(feature = "bit")]
@@ -687,6 +710,7 @@ impl FlowLikeState {
             page_registry: Arc::new(DashMap::new()),
 
             package_widget_source: self.package_widget_source.clone(),
+            app_widget_source: self.app_widget_source.clone(),
         }
     }
 

--- a/packages/core/tests/compiled_board_roundtrip.rs
+++ b/packages/core/tests/compiled_board_roundtrip.rs
@@ -441,3 +441,36 @@ fn reconstructed_view_preserves_execution_fields() {
 
     let _ = NONE_IDX;
 }
+
+/// The executor builds its template from fetched bytes and nothing else, so
+/// every way those bytes can be wrong has to surface as an error it can act
+/// on — never as a silent recompile, which it no longer has.
+#[test]
+fn template_from_bytes_rejects_foreign_or_broken_artifacts() {
+    use flow_like::flow::compiled::template_from_bytes;
+    use flow_like::state::FlowNodeRegistryInner;
+
+    let mut board = empty_board();
+    board
+        .nodes
+        .insert("n".into(), node_with_pins("n", "lonely", vec![]));
+    let compiled = compile_board(&board).expect("compile");
+    let registry = FlowNodeRegistryInner::new(0);
+    let root = Path::from("apps").child("test");
+
+    let compiled_with = [1u8; 32];
+    let bytes = encode_artifact(&compiled, &compiled_with).expect("encode");
+    let error = template_from_bytes(&bytes, &[2u8; 32], &registry, &root)
+        .err()
+        .expect("a foreign fingerprint is rejected before decoding");
+    let message = error.to_string();
+    let theirs = blake3::Hash::from_bytes(compiled_with).to_hex();
+    let ours = blake3::Hash::from_bytes([2u8; 32]).to_hex();
+    assert!(message.contains(&theirs.as_str()[..16]), "{message}");
+    assert!(message.contains(&ours.as_str()[..16]), "{message}");
+
+    assert!(
+        template_from_bytes(b"not an artifact", &compiled_with, &registry, &root).is_err(),
+        "garbage bytes are an error, not a template"
+    );
+}

--- a/packages/executor/src/execute.rs
+++ b/packages/executor/src/execute.rs
@@ -5,9 +5,11 @@
 use crate::config::ExecutorConfig;
 use crate::error::ExecutorError;
 use crate::jwt::{verify_jwt_async, ExecutorClaims, ExecutorPageExecutionClaims};
+use crate::resolve::{fetch_bounded, max_remote_payload_bytes};
 use crate::types::{EventType, ExecutionEvent, ExecutionRequest, ExecutionResult, ExecutionStatus};
+use crate::widgets::{HubAccess, HubWidgetSource};
 use flow_like::credentials::StoreType;
-use flow_like::flow::compiled::{CompiledRunTemplate, TemplateCache};
+use flow_like::flow::compiled::{CompiledRunTemplate, TemplateCache, template_from_bytes};
 use flow_like::flow::event::Event;
 use flow_like::flow::execution::rejection::{RejectedRun, RejectionStage};
 use flow_like::flow::execution::{ExecutionEnvironment, InternalRun, RunPayload};
@@ -65,30 +67,97 @@ fn wasm_registry_signature(request: &ExecutionRequest) -> String {
     flow_like_types::dispatch::wasm_package_set_revision(request.wasm_packages.as_ref())
 }
 
-/// Resolve the request's board into a shared run template via the core
-/// resolver: in-process cache → persisted artifact → compile + write-back.
-/// The per-request WASM bundle signature salts the cache key so bundles with
-/// changed package content never share a template.
+/// Resolve the request's board into a shared run template from the compiled
+/// artifact the API presigned into the dispatch payload.
+///
+/// The API compiled and persisted the `.flcb` before dispatch and handed us a
+/// GET for exactly that object, so this runtime never reads a board proto,
+/// never compiles and never writes anything back — it has no storage
+/// credential that could. The cache is keyed on the board's content identity
+/// (pinned version or source ETag), the registry fingerprint and the WASM
+/// bundle signature, so a hit needs no revalidation. Anything short of a
+/// decodable artifact for our own registry fails the run at Resolution.
 pub(crate) async fn resolve_run_template(
     state: &Arc<FlowLikeState>,
     request: &ExecutionRequest,
 ) -> Result<Arc<CompiledRunTemplate>, ExecutorError> {
-    TEMPLATE_CACHE
-        .resolve(
-            state,
-            &request.app_id,
-            &request.board_id,
-            request.board_version,
-            request.board_etag.as_deref(),
-            &wasm_registry_signature(request),
-        )
+    let registry = state.node_registry.read().await.node_registry.clone();
+    let fingerprint = registry.fingerprint();
+    let version_key = artifact_version_key(request)?;
+    let cache_key = TemplateCache::cache_key(
+        &request.app_id,
+        &request.board_id,
+        &version_key,
+        &fingerprint,
+        &wasm_registry_signature(request),
+    );
+    if let Some(template) = TEMPLATE_CACHE.get(&cache_key) {
+        tracing::debug!(cache_key = %cache_key, "Template cache hit");
+        return Ok(template);
+    }
+
+    // The URL is a bearer capability: fetch errors name the object path only.
+    let bytes = fetch_bounded(&request.artifact.url, max_remote_payload_bytes())
         .await
         .map_err(|e| {
             ExecutorError::BoardLoad(format!(
-                "Failed to resolve board {}: {}",
-                request.board_id, e
+                "failed to fetch compiled artifact {} for board {}: {e}",
+                request.artifact.path, request.board_id
             ))
-        })
+        })?;
+    let template = template_from_fetched(&bytes, &fingerprint, registry.as_ref(), request)?;
+    TEMPLATE_CACHE.insert(cache_key, template.clone());
+    Ok(template)
+}
+
+/// The content identity half of the template cache key. Pinned versions are
+/// immutable; a floating board is pinned to the source ETag the API compiled
+/// from — the Page-claim ETag when the run carries one, otherwise the one the
+/// API resolved for an ordinary run and sent with the artifact reference.
+fn artifact_version_key(request: &ExecutionRequest) -> Result<String, ExecutorError> {
+    match (
+        request.board_version,
+        request.board_etag.as_deref(),
+        request.artifact.source_etag.as_deref(),
+    ) {
+        (Some((m, n, p)), _, _) => Ok(format!("{m}_{n}_{p}")),
+        (None, Some(etag), _) | (None, None, Some(etag)) => Ok(format!("latest@{etag}")),
+        (None, None, None) => Err(ExecutorError::BoardLoad(format!(
+            "floating Latest run of board {} carries no source etag in its compiled artifact reference",
+            request.board_id
+        ))),
+    }
+}
+
+/// Decode fetched artifact bytes into a template for this request. Split from
+/// the fetch so it is testable with in-memory bytes.
+pub(crate) fn template_from_fetched(
+    bytes: &[u8],
+    fingerprint: &[u8; 32],
+    registry: &FlowNodeRegistryInner,
+    request: &ExecutionRequest,
+) -> Result<Arc<CompiledRunTemplate>, ExecutorError> {
+    let storage_root = Path::from("apps").child(request.app_id.clone());
+    let template = template_from_bytes(bytes, fingerprint, registry, &storage_root).map_err(|e| {
+        let ours = blake3::Hash::from_bytes(*fingerprint).to_hex();
+        ExecutorError::BoardLoad(format!(
+            "compiled artifact {} rejected: {e} (API compiled against {}, this executor runs {})",
+            request.artifact.path,
+            request
+                .artifact
+                .registry_fingerprint
+                .get(..16)
+                .unwrap_or(&request.artifact.registry_fingerprint),
+            &ours.as_str()[..16]
+        ))
+    })?;
+    if template.board.id != request.board_id {
+        return Err(ExecutorError::BoardLoad(format!(
+            "compiled artifact {} is for board {}, expected {}",
+            request.artifact.path, template.board.id, request.board_id
+        )));
+    }
+    Ok(template)
 }
 
 fn validate_page_request_binding(
@@ -195,18 +264,22 @@ pub(crate) fn validate_executor_request_claims(
 }
 
 /// Build the `FlowLikeState` every execution path shares: stores from the
-/// request credentials, the logs database builder, and the server execution
-/// environment. WASM registry overlays are applied by the caller.
+/// request credentials, the logs database builder, the server execution
+/// environment and — when the run has a hub — the widget source that keeps
+/// `Instantiate Widget` off the meta store. WASM registry overlays are applied
+/// by the caller.
+///
+/// There is deliberately no meta store. Boards arrive as presigned compiled
+/// artifacts and widgets come from the hub, so the run credential carries no
+/// meta grant — and `with_default_store` would otherwise alias the meta slot
+/// to the content bucket, letting any stray meta read land on the wrong data.
+/// Leaving it `None` makes such a read fail loudly instead.
 pub(crate) async fn build_flow_state(
     credentials: &flow_like::credentials::SharedCredentials,
+    hub: Option<HubAccess>,
 ) -> Result<FlowLikeState, ExecutorError> {
     let content_store = credentials
         .to_store_type(StoreType::Content)
-        .await
-        .map_err(|e| ExecutorError::Storage(e.to_string()))?;
-
-    let meta_store = credentials
-        .to_store_type(StoreType::Meta)
         .await
         .map_err(|e| ExecutorError::Storage(e.to_string()))?;
 
@@ -216,7 +289,7 @@ pub(crate) async fn build_flow_state(
         .map_err(|e| ExecutorError::Storage(e.to_string()))?;
 
     let mut flow_config = FlowLikeConfig::with_default_store(content_store);
-    flow_config.register_app_meta_store(meta_store);
+    flow_config.stores.app_meta_store = None;
     flow_config.register_log_store(log_store);
 
     // Request-file offloads and `/tmp` uploads live under tmp/*, which the
@@ -246,6 +319,14 @@ pub(crate) async fn build_flow_state(
     let mut state =
         FlowLikeState::new_with_model_config(flow_config, http_client, model_provider_config);
     state.execution_environment = ExecutionEnvironment::server_default();
+    if let Some(hub) = hub {
+        state
+            .register_app_widget_source(Arc::new(HubWidgetSource::new(
+                &hub.callback_url,
+                hub.jwt,
+            )))
+            .await;
+    }
     Ok(state)
 }
 
@@ -258,7 +339,7 @@ pub(crate) async fn record_claims_rejection(
     run_id: &str,
     error: &ExecutorError,
 ) {
-    match build_flow_state(&request.credentials).await {
+    match build_flow_state(&request.credentials, None).await {
         Ok(state) => {
             record_executor_rejection(
                 &Arc::new(state),
@@ -475,7 +556,14 @@ pub async fn execute(
     };
 
     // Build FlowLike state from the request credentials
-    let state = build_flow_state(&request.credentials).await?;
+    let state = build_flow_state(
+        &request.credentials,
+        Some(HubAccess {
+            callback_url: claims.callback_url.clone(),
+            jwt: request.executor_jwt.clone(),
+        }),
+    )
+    .await?;
     let execution_environment = state.execution_environment;
 
     // Set up event channel for API callback batching
@@ -1507,9 +1595,80 @@ mod shadow_claim_binding_tests {
                     "expiration": null
                 }
             },
-            "executor_jwt": "jwt"
+            "executor_jwt": "jwt",
+            "artifact": {
+                "url": "https://meta.example/apps/app-1/compiled/board-1/1_0_0.flcb?sig",
+                "path": "apps/app-1/compiled/board-1/1_0_0.flcb",
+                "registry_fingerprint": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            }
         }))
         .expect("request deserializes")
+    }
+
+    /// Bytes the API would have persisted: a board holding one real catalog
+    /// node, compiled and encoded against the prepared registry.
+    fn artifact_bytes_for(board_id: &str, fingerprint: &[u8; 32]) -> Vec<u8> {
+        use flow_like::flow::board::Board;
+        use flow_like::flow::compiled::{compile::compile_board_with_catalog, encode_artifact};
+
+        let registry = PREPARED_REGISTRY.clone();
+        let mut node = registry
+            .get_nodes()
+            .into_iter()
+            .next()
+            .expect("the catalog is not empty");
+        node.id = "n1".into();
+        let mut board = Board::new_detached(
+            Some(board_id.to_string()),
+            Path::from("apps").child("app-1"),
+        );
+        board.nodes.insert(node.id.clone(), node);
+        let compiled = compile_board_with_catalog(&board, registry.as_ref()).expect("compile");
+        encode_artifact(&compiled, fingerprint).expect("encode")
+    }
+
+    #[test]
+    fn fetched_artifact_bytes_become_a_template_for_exactly_the_requested_board() {
+        let registry = PREPARED_REGISTRY.clone();
+        let fingerprint = registry.fingerprint();
+        let request = request(false);
+
+        let template =
+            template_from_fetched(&artifact_bytes_for("board-1", &fingerprint), &fingerprint, registry.as_ref(), &request)
+                .expect("an artifact for this board and registry is accepted");
+        assert_eq!(template.board.id, "board-1");
+
+        let error = template_from_fetched(&artifact_bytes_for("board-9", &fingerprint), &fingerprint, registry.as_ref(), &request)
+            .err()
+            .expect("an artifact for another board is refused");
+        assert!(error.to_string().contains("board-9"), "{error}");
+
+        let error = template_from_fetched(&artifact_bytes_for("board-1", &[9u8; 32]), &fingerprint, registry.as_ref(), &request)
+            .err()
+            .expect("an artifact for another registry is refused");
+        assert!(error.to_string().contains("this executor runs"), "{error}");
+    }
+
+    #[test]
+    fn the_cache_key_pins_a_floating_run_to_the_artifacts_source_etag() {
+        let mut request = request(false);
+        request.artifact.source_etag = Some("etag-a".into());
+        assert_eq!(artifact_version_key(&request).unwrap(), "latest@etag-a");
+
+        request.board_etag = Some("etag-page".into());
+        assert_eq!(
+            artifact_version_key(&request).unwrap(),
+            "latest@etag-page",
+            "a Page run's authorized ETag wins over the resolved one"
+        );
+
+        request.board_etag = None;
+        request.board_version = Some((1, 2, 3));
+        assert_eq!(artifact_version_key(&request).unwrap(), "1_2_3");
+
+        request.board_version = None;
+        request.artifact.source_etag = None;
+        assert!(artifact_version_key(&request).is_err(), "no identity, no key");
     }
 
     /// The in-process isolation is driven by the signed claim, never by the

--- a/packages/executor/src/lib.rs
+++ b/packages/executor/src/lib.rs
@@ -38,6 +38,7 @@ pub mod router;
 pub mod streaming;
 pub mod types;
 pub mod wasm_loader;
+pub mod widgets;
 
 pub use config::ExecutorConfig;
 pub use error::ExecutorError;

--- a/packages/executor/src/resolve.rs
+++ b/packages/executor/src/resolve.rs
@@ -50,15 +50,29 @@ pub async fn resolve_payload(
 /// GET a presigned URL with connect/total timeouts, redirects refused, and the
 /// response body capped at `max_bytes`.
 pub async fn fetch_bounded(url: &str, max_bytes: u64) -> Result<Vec<u8>, ResolveError> {
+    fetch_bounded_with(url, None, max_bytes).await
+}
+
+/// [`fetch_bounded`] with an optional bearer token, for hub endpoints that
+/// authenticate the executor by its JWT rather than by a presigned URL.
+pub async fn fetch_bounded_with(
+    url: &str,
+    bearer: Option<&str>,
+    max_bytes: u64,
+) -> Result<Vec<u8>, ResolveError> {
     let client = reqwest::Client::builder()
+        .user_agent(concat!("flow-like-executor/", env!("CARGO_PKG_VERSION")))
         .redirect(reqwest::redirect::Policy::none())
         .connect_timeout(FETCH_CONNECT_TIMEOUT)
         .timeout(FETCH_TIMEOUT)
         .build()
         .map_err(|e| ResolveError::Fetch(e.to_string()))?;
 
-    let mut response = client
-        .get(url)
+    let mut request = client.get(url);
+    if let Some(token) = bearer {
+        request = request.bearer_auth(token);
+    }
+    let mut response = request
         .send()
         .await
         .map_err(|e| ResolveError::Fetch(e.to_string()))?;

--- a/packages/executor/src/router.rs
+++ b/packages/executor/src/router.rs
@@ -194,7 +194,13 @@ mod tests {
             },
             "executor_jwt": "jwt",
             "callback_url": "https://api.example",
-            "stream_state": true
+            "stream_state": true,
+            "artifact": {
+                "url": "https://meta.example/tmp/apps/app-1/compiled/drafts/board-1/etag-a_fp.flcb?sig",
+                "path": "tmp/apps/app-1/compiled/drafts/board-1/etag-a_fp.flcb",
+                "source_etag": "etag-a",
+                "registry_fingerprint": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            }
         }))
         .expect("wire payload deserializes as DispatchPayload")
     }

--- a/packages/executor/src/streaming.rs
+++ b/packages/executor/src/streaming.rs
@@ -185,7 +185,14 @@ async fn execute_inner(
     ),
     ExecutorError,
 > {
-    let state = crate::execute::build_flow_state(&request.credentials).await?;
+    let state = crate::execute::build_flow_state(
+        &request.credentials,
+        Some(crate::widgets::HubAccess {
+            callback_url: callback_url.to_string(),
+            jwt: request.executor_jwt.clone(),
+        }),
+    )
+    .await?;
     let execution_environment = state.execution_environment;
 
     let mut wasm_nodes = Vec::new();

--- a/packages/executor/src/types.rs
+++ b/packages/executor/src/types.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub use flow_like_types::channel::ChannelGrant;
-pub use flow_like_types::dispatch::{DispatchPayload, WasmPackageRef};
+pub use flow_like_types::dispatch::{CompiledArtifactRef, DispatchPayload, WasmPackageRef};
 
 /// Board version as a tuple (major, minor, patch)
 pub type BoardVersion = (u32, u32, u32);
@@ -73,6 +73,10 @@ pub struct ExecutionRequest {
     /// against the signed executor JWT claim before execution starts.
     #[serde(default)]
     pub shadow: bool,
+    /// The compiled board to run, as a presigned GET the API minted after
+    /// assuring the artifact exists. Required: this runtime has no other way to
+    /// obtain a board, so a payload without it is rejected rather than run.
+    pub artifact: CompiledArtifactRef,
 }
 
 /// Result of an execution
@@ -188,6 +192,11 @@ impl TryFrom<DispatchPayload> for ExecutionRequest {
         };
 
         let (board_version, board_etag) = decode_board_selector(p.board_version, p.board_etag)?;
+        let artifact = p.artifact.ok_or_else(|| {
+            flow_like_types::anyhow!(
+                "dispatch payload carries no compiled artifact reference; the API must be upgraded before this executor"
+            )
+        })?;
 
         Ok(Self {
             job_id: p.job_id,
@@ -210,6 +219,7 @@ impl TryFrom<DispatchPayload> for ExecutionRequest {
             wasm_packages: p.wasm_packages,
             channel: p.channel,
             shadow: p.shadow,
+            artifact,
         })
     }
 }
@@ -264,8 +274,29 @@ mod tests {
             },
             "executor_jwt": "jwt",
             "callback_url": "https://api.example",
-            "stream_state": true
+            "stream_state": true,
+            "artifact": {
+                "url": "https://meta.example/tmp/apps/app-1/compiled/drafts/board-1/etag-a_fp.flcb?sig",
+                "path": "tmp/apps/app-1/compiled/drafts/board-1/etag-a_fp.flcb",
+                "source_etag": "etag-a",
+                "registry_fingerprint": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+            }
         })
+    }
+
+    #[test]
+    fn a_payload_without_a_compiled_artifact_is_rejected() {
+        let mut json = etag_latest_wire_json();
+        json.as_object_mut().unwrap().remove("artifact");
+        let payload: DispatchPayload =
+            serde_json::from_value(json).expect("the wire field is optional");
+        let error = ExecutionRequest::try_from(payload)
+            .err()
+            .expect("an executor cannot run without an artifact reference");
+        assert!(
+            error.to_string().contains("compiled artifact reference"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/packages/executor/src/widgets.rs
+++ b/packages/executor/src/widgets.rs
@@ -1,0 +1,115 @@
+//! Declarative widgets for a run, fetched from the hub instead of the meta store.
+//!
+//! The `Instantiate Widget` node used to read `apps/{app}/manifest.app` and
+//! every `{widget}.widget` straight from meta storage, which was the one
+//! run-time read that kept a storage credential in the executor. The hub
+//! already authenticates this executor by its JWT for progress reporting, so
+//! widgets travel the same way: one authenticated GET per app per run, cached
+//! for the life of the run so N instantiations of the same widget cost one call.
+
+use crate::resolve::{fetch_bounded_with, max_remote_payload_bytes};
+use flow_like::a2ui::micro_widget::AppWidgetSource;
+use flow_like::a2ui::widget::Widget;
+use flow_like_types::{anyhow, async_trait};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// How a run reaches its hub: the callback URL from the executor JWT claims
+/// and the JWT itself, which the hub accepts as this executor's identity.
+pub(crate) struct HubAccess {
+    pub callback_url: String,
+    pub jwt: String,
+}
+
+pub struct HubWidgetSource {
+    base_url: String,
+    jwt: String,
+    cache: Mutex<HashMap<String, Arc<Vec<Widget>>>>,
+}
+
+impl HubWidgetSource {
+    pub fn new(callback_url: &str, jwt: String) -> Self {
+        Self {
+            base_url: callback_url.trim_end_matches('/').to_string(),
+            jwt,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The hub route serving an app's declarative widgets to its executors.
+    pub fn widgets_url(&self, app_id: &str) -> String {
+        format!("{}/api/v1/execution/apps/{app_id}/widgets", self.base_url)
+    }
+
+    async fn fetch(&self, app_id: &str) -> flow_like_types::Result<Vec<Widget>> {
+        let url = self.widgets_url(app_id);
+        // The JWT is a bearer credential: it goes in the header and never in an
+        // error, which is why the failure below names the app, not the request.
+        let body = fetch_bounded_with(&url, Some(&self.jwt), max_remote_payload_bytes())
+            .await
+            .map_err(|e| anyhow!("failed to load widgets of app {app_id} from the hub: {e}"))?;
+        serde_json::from_slice(&body)
+            .map_err(|e| anyhow!("hub returned unreadable widgets for app {app_id}: {e}"))
+    }
+
+    #[cfg(test)]
+    async fn prime(&self, app_id: &str, widgets: Vec<Widget>) {
+        self.cache
+            .lock()
+            .await
+            .insert(app_id.to_string(), Arc::new(widgets));
+    }
+}
+
+#[async_trait]
+impl AppWidgetSource for HubWidgetSource {
+    async fn list_app_widgets(&self, app_id: &str) -> flow_like_types::Result<Arc<Vec<Widget>>> {
+        if let Some(widgets) = self.cache.lock().await.get(app_id) {
+            return Ok(widgets.clone());
+        }
+        let widgets = Arc::new(self.fetch(app_id).await?);
+        self.cache
+            .lock()
+            .await
+            .insert(app_id.to_string(), widgets.clone());
+        Ok(widgets)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn widgets_url_is_the_hub_execution_route_without_a_double_slash() {
+        let source = HubWidgetSource::new("https://api.example/", "jwt".into());
+        assert_eq!(
+            source.widgets_url("app-1"),
+            "https://api.example/api/v1/execution/apps/app-1/widgets"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_cached_app_is_served_without_touching_the_network() {
+        // Port 9 (discard) refuses connections, so any fetch would fail loudly.
+        let source = HubWidgetSource::new("http://127.0.0.1:9", "jwt".into());
+        source.prime("app-1", Vec::new()).await;
+        let first = source.list_app_widgets("app-1").await.expect("served from cache");
+        let second = source.list_app_widgets("app-1").await.expect("served from cache");
+        assert!(Arc::ptr_eq(&first, &second), "one entry, shared across calls");
+    }
+
+    #[tokio::test]
+    async fn an_unknown_app_reaches_the_hub_and_reports_the_app_not_the_token() {
+        let source = HubWidgetSource::new("http://127.0.0.1:9", "secret-jwt".into());
+        let error = source
+            .list_app_widgets("app-2")
+            .await
+            .err()
+            .expect("connection refused");
+        let message = error.to_string();
+        assert!(message.contains("app-2"), "{message}");
+        assert!(!message.contains("secret-jwt"), "{message}");
+    }
+}

--- a/packages/types/contracts/src/dispatch.rs
+++ b/packages/types/contracts/src/dispatch.rs
@@ -191,6 +191,25 @@ pub enum CompilationStatus {
     Failed,
 }
 
+/// The compiled board an executor runs, delivered as a presigned GET so the
+/// executor needs no storage credential to obtain it. Produced by the API's
+/// pre-dispatch artifact assurance; consumed verbatim by the executor.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CompiledArtifactRef {
+    /// Presigned GET for the `.flcb` object.
+    pub url: String,
+    /// Object key on the API's meta store. Diagnostics only — the executor never addresses storage.
+    pub path: String,
+    /// ETag of the source `.board` the artifact was compiled from, for floating Latest runs
+    /// (`None` for versioned runs, whose identity is the version). The executor keys its
+    /// template cache on it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_etag: Option<String>,
+    /// Hex blake3 fingerprint of the registry the API compiled against. The executor validates the
+    /// artifact header against its own registry; this value only makes a mismatch diagnosable.
+    pub registry_fingerprint: String,
+}
+
 /// Payload produced by the API dispatcher and consumed by every executor runtime
 /// (HTTP, Lambda, SQS, Redis, Kafka, Kubernetes).
 ///
@@ -243,6 +262,11 @@ pub struct DispatchPayload {
     /// request when the two disagree.
     #[serde(default)]
     pub shadow: bool,
+    /// Compiled `.flcb` the executor runs, as a presigned GET. Optional on the
+    /// wire so an executor that predates it ignores the field; current executors
+    /// require it and fail closed when it is absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<CompiledArtifactRef>,
 }
 
 /// Reference to a dispatch payload that may be either embedded inline or


### PR DESCRIPTION
- Introduced `AppWidgetSource` trait to allow fetching app widgets from a host-registered source.
- Implemented `load_app_widgets` function to retrieve widgets either from the registered source or fallback to the local store.
- Added `HubWidgetSource` to fetch widgets from the hub API, caching results for efficiency.
- Updated `FlowLikeState` to support registering an app widget source.
- Modified `InstantiateWidget` logic to utilize the new widget loading mechanism.
- Enhanced error handling for widget loading failures.
- Added tests for the new widget source functionality and caching behavior.
- Updated executor to use presigned URLs for fetching compiled artifacts, ensuring no storage credentials are required.
- Refactored template resolution logic to handle compiled artifacts directly from the API.