### PR TITLE
Refactor path construction to use `join` instead of `child`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3381,7 +3381,7 @@ dependencies = [
  "futures 0.3.32",
  "indexmap 2.14.0",
  "itertools 0.14.0",
- "object_store 0.13.2",
+ "object_store",
  "parquet",
  "percent-encoding",
  "rand 0.9.3",
@@ -5508,7 +5508,7 @@ dependencies = [
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store 0.13.2",
+ "object_store",
  "parking_lot",
  "parquet",
  "rand 0.9.3",
@@ -5542,7 +5542,7 @@ dependencies = [
  "futures 0.3.32",
  "itertools 0.14.0",
  "log",
- "object_store 0.13.2",
+ "object_store",
  "parking_lot",
  "tokio",
 ]
@@ -5567,7 +5567,7 @@ dependencies = [
  "futures 0.3.32",
  "itertools 0.14.0",
  "log",
- "object_store 0.13.2",
+ "object_store",
 ]
 
 [[package]]
@@ -5586,7 +5586,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "log",
- "object_store 0.13.2",
+ "object_store",
  "parquet",
  "paste",
  "recursive",
@@ -5633,7 +5633,7 @@ dependencies = [
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store 0.13.2",
+ "object_store",
  "rand 0.9.3",
  "tokio",
  "tokio-util",
@@ -5661,7 +5661,7 @@ dependencies = [
  "datafusion-session",
  "futures 0.3.32",
  "itertools 0.14.0",
- "object_store 0.13.2",
+ "object_store",
  "tokio",
 ]
 
@@ -5683,7 +5683,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures 0.3.32",
- "object_store 0.13.2",
+ "object_store",
  "regex",
  "tokio",
 ]
@@ -5706,7 +5706,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures 0.3.32",
- "object_store 0.13.2",
+ "object_store",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -5736,7 +5736,7 @@ dependencies = [
  "futures 0.3.32",
  "itertools 0.14.0",
  "log",
- "object_store 0.13.2",
+ "object_store",
  "parking_lot",
  "parquet",
  "tokio",
@@ -5764,7 +5764,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "futures 0.3.32",
  "log",
- "object_store 0.13.2",
+ "object_store",
  "parking_lot",
  "rand 0.9.3",
  "tempfile",
@@ -6117,7 +6117,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-proto-common",
- "object_store 0.13.2",
+ "object_store",
  "prost 0.14.3",
  "rand 0.9.3",
 ]
@@ -6344,7 +6344,7 @@ dependencies = [
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "num_cpus",
- "object_store 0.13.2",
+ "object_store",
  "parking_lot",
  "parquet",
  "percent-encoding",
@@ -9424,7 +9424,7 @@ dependencies = [
  "lance-io",
  "lancedb",
  "num_cpus",
- "object_store 0.13.2",
+ "object_store",
  "petgraph",
  "schemars 1.2.1",
  "serde",
@@ -9462,7 +9462,7 @@ dependencies = [
  "futures 0.3.32",
  "infer 0.19.0",
  "mime_guess",
- "object_store 0.13.2",
+ "object_store",
  "percent-encoding",
  "reqwest 0.12.28",
  "schemars 1.2.1",
@@ -14023,7 +14023,7 @@ dependencies = [
  "lance-tokenizer",
  "log",
  "moka",
- "object_store 0.13.2",
+ "object_store",
  "permutation",
  "pin-project",
  "prost 0.14.3",
@@ -14123,7 +14123,7 @@ dependencies = [
  "log",
  "moka",
  "num_cpus",
- "object_store 0.13.2",
+ "object_store",
  "pin-project",
  "prost 0.14.3",
  "rand 0.9.3",
@@ -14258,7 +14258,7 @@ dependencies = [
  "lance-io",
  "log",
  "num-traits 0.2.19",
- "object_store 0.13.2",
+ "object_store",
  "prost 0.14.3",
  "prost-build",
  "prost-types 0.14.3",
@@ -14372,7 +14372,7 @@ dependencies = [
  "log",
  "ndarray 0.16.1",
  "num-traits 0.2.19",
- "object_store 0.13.2",
+ "object_store",
  "prost 0.14.3",
  "prost-build",
  "prost-types 0.14.3",
@@ -14419,7 +14419,7 @@ dependencies = [
  "lance-namespace",
  "log",
  "moka",
- "object_store 0.13.2",
+ "object_store",
  "object_store_opendal",
  "opendal",
  "path_abs",
@@ -14487,7 +14487,7 @@ dependencies = [
  "lance-namespace",
  "lance-table",
  "log",
- "object_store 0.13.2",
+ "object_store",
  "quick-xml 0.38.4",
  "rand 0.9.3",
  "reqwest 0.12.28",
@@ -14554,7 +14554,7 @@ dependencies = [
  "lance-io",
  "lance-select",
  "log",
- "object_store 0.13.2",
+ "object_store",
  "prost 0.14.3",
  "prost-build",
  "prost-types 0.14.3",
@@ -14648,7 +14648,7 @@ dependencies = [
  "log",
  "moka",
  "num-traits 0.2.19",
- "object_store 0.13.2",
+ "object_store",
  "pin-project",
  "rand 0.9.3",
  "regex",
@@ -15850,7 +15850,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 [[package]]
 name = "markitdown"
 version = "0.2.0"
-source = "git+https://github.com/Rheosoph/markitdown-rs.git?rev=2dac5f1#2dac5f1eeca24a9a538b9094ee121da96fafcd7b"
+source = "git+https://github.com/Rheosoph/markitdown-rs.git?rev=1bd98da0de6f90143b25452d74b275da21f2d175#1bd98da0de6f90143b25452d74b275da21f2d175"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15875,7 +15875,7 @@ dependencies = [
  "liteparse",
  "mail-parser",
  "mime_guess",
- "object_store 0.12.5",
+ "object_store",
  "quick-xml 0.39.4",
  "rbook",
  "regex",
@@ -17780,44 +17780,6 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bytes",
- "chrono",
- "form_urlencoded",
- "futures 0.3.32",
- "http 1.4.0",
- "http-body-util",
- "httparse",
- "humantime",
- "hyper 1.10.1",
- "itertools 0.14.0",
- "md-5 0.10.6",
- "parking_lot",
- "percent-encoding",
- "quick-xml 0.38.4",
- "rand 0.9.3",
- "reqwest 0.12.28",
- "ring",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "url",
- "walkdir",
- "wasm-bindgen-futures",
- "web-time",
-]
-
-[[package]]
-name = "object_store"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
@@ -17867,7 +17829,7 @@ dependencies = [
  "chrono",
  "futures 0.3.32",
  "mea",
- "object_store 0.13.2",
+ "object_store",
  "opendal",
  "pin-project",
  "tokio",
@@ -18714,7 +18676,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits 0.2.19",
- "object_store 0.13.2",
+ "object_store",
  "paste",
  "ring",
  "seq-macro",
@@ -27358,7 +27320,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "video-utils-rs"
 version = "0.1.0"
-source = "git+https://github.com/Rheosoph/video-utils-rs.git?rev=4b4e380fd719390dd8598120ebfb50566d234d5c#4b4e380fd719390dd8598120ebfb50566d234d5c"
+source = "git+https://github.com/Rheosoph/video-utils-rs.git?rev=b4c9185504f98b1eb8eb9d34c8baa0b6f5f8cab4#b4c9185504f98b1eb8eb9d34c8baa0b6f5f8cab4"
 dependencies = [
  "ab_glyph",
  "bytes",
@@ -27374,7 +27336,7 @@ dependencies = [
  "m3u8-rs",
  "matroska-demuxer",
  "muxide",
- "object_store 0.12.5",
+ "object_store",
  "png 0.18.1",
  "rav1e",
  "ravif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,7 +267,7 @@ thiserror = "2.0.17"
 mimalloc = { version = "0.1.48", default-features = false }
 lettre = { version = "0.11.22", default-features = false, features = ["tokio1-rustls-tls", "builder", "hostname", "pool", "smtp-transport"] }
 reqwest = { version = "0.12.28", default-features = false, features = ["json", "rustls-tls"] }
-markitdown = { git = "https://github.com/Rheosoph/markitdown-rs.git", rev = "2dac5f1", default-features = false, features = ["rustls-tls", "static-liblzma"] }
+markitdown = { git = "https://github.com/Rheosoph/markitdown-rs.git", rev = "1bd98da0de6f90143b25452d74b275da21f2d175", default-features = false, features = ["rustls-tls", "static-liblzma"] }
 kube = { version = "0.98", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.24", features = ["v1_32"] }
 percent-encoding = "2.3.2"

--- a/apps/desktop/src-tauri/src/event_bus.rs
+++ b/apps/desktop/src-tauri/src/event_bus.rs
@@ -306,7 +306,7 @@ impl EventBusEvent {
                 let db_fn = db_fn
                     .as_ref()
                     .ok_or_else(|| flow_like_types::anyhow!("No log database configured"))?;
-                let base_path = Path::from("runs").child(app_id).child(board_id);
+                let base_path = Path::from("runs").join(app_id).join(board_id);
                 let db = execution_state
                     .with_lance_session(db_fn(base_path.clone()))
                     .execute()

--- a/apps/desktop/src-tauri/src/functions/a2ui/page.rs
+++ b/apps/desktop/src-tauri/src/functions/a2ui/page.rs
@@ -45,7 +45,7 @@ pub struct PageInfo {
 fn detached_board(app_id: &str, board_id: &str, state: Arc<FlowLikeState>) -> Board {
     Board::new(
         Some(board_id.to_string()),
-        Path::from("apps").child(app_id.to_string()),
+        Path::from("apps").join(app_id.to_string()),
         state,
     )
 }

--- a/apps/desktop/src-tauri/src/functions/app.rs
+++ b/apps/desktop/src-tauri/src/functions/app.rs
@@ -45,7 +45,7 @@ async fn presign_meta(
         .app_storage_store
         .clone()
         .ok_or_else(|| TauriFunctionError::new("App storage store not found"))?;
-    let prefix = Path::from("apps").child(app_id).child("media");
+    let prefix = Path::from("apps").join(app_id).join("media");
     metadata.presign(prefix, &store).await;
     Ok(())
 }
@@ -419,7 +419,7 @@ pub async fn push_app_media(
         .clone()
         .ok_or(anyhow!("Project store not found"))?;
 
-    let media_path = Path::from("apps").child(app_id.clone()).child("media");
+    let media_path = Path::from("apps").join(app_id.clone()).join("media");
     let item_id = create_id();
     let item_name = format!("{}.{}", item_id, query.extension);
     let mut meta = App::get_meta(
@@ -450,13 +450,13 @@ pub async fn push_app_media(
     meta.updated_at = SystemTime::now();
     if let Some(to_delete) = to_delete {
         let file_name = format!("{}.webp", to_delete);
-        let path = media_path.child(file_name);
+        let path = media_path.clone().join(file_name);
         if let Err(err) = project_store.as_generic().delete(&path).await {
             tracing::error!("Failed to delete existing media at {}: {:?}", path, err);
         }
     }
 
-    let media_path = media_path.child(item_name);
+    let media_path = media_path.join(item_name);
     let upload_url = project_store
         .sign("PUT", &media_path, Duration::from_secs(60 * 60 * 24))
         .await
@@ -484,7 +484,7 @@ pub async fn remove_app_media(
         .clone()
         .ok_or(anyhow!("Project store not found"))?;
 
-    let media_path = Path::from("apps").child(app_id.clone()).child("media");
+    let media_path = Path::from("apps").join(app_id.clone()).join("media");
     let item_name = format!("{}.webp", media_item);
     let mut meta = App::get_meta(
         app_id.clone(),
@@ -510,7 +510,7 @@ pub async fn remove_app_media(
 
     meta.updated_at = SystemTime::now();
 
-    let media_path = media_path.child(item_name);
+    let media_path = media_path.join(item_name);
     if let Err(err) = project_store.as_generic().delete(&media_path).await {
         tracing::error!("Failed to delete media at {}: {:?}", media_path, err);
         return Err(TauriFunctionError::new("Failed to delete media"));
@@ -538,8 +538,8 @@ pub async fn transform_media(
         .clone()
         .ok_or(anyhow!("Project store not found"))?;
 
-    let media_path = Path::from("apps").child(app_id.clone()).child("media");
-    let from_image = media_path.child(media_item.clone());
+    let media_path = Path::from("apps").join(app_id.clone()).join("media");
+    let from_image = media_path.clone().join(media_item.clone());
 
     let extension = from_image
         .extension()
@@ -554,7 +554,7 @@ pub async fn transform_media(
         media_item.trim_end_matches(&format!(".{}", extension))
     );
 
-    let to_image = media_path.child(transformed_name);
+    let to_image = media_path.join(transformed_name);
 
     let image_data = project_store
         .as_generic()
@@ -621,7 +621,7 @@ pub async fn get_app_size(
     app_id: String,
 ) -> Result<u64, TauriFunctionError> {
     let content_store = TauriFlowLikeState::get_project_storage_store(&app_handle).await?;
-    let path = Path::from("apps").child(app_id);
+    let path = Path::from("apps").join(app_id);
 
     let mut locations = content_store
         .list(Some(&path))
@@ -658,7 +658,7 @@ pub async fn delete_app(app_handle: AppHandle, app_id: String) -> Result<(), Tau
     settings.serialize();
     drop(settings);
 
-    let path = Path::from("apps").child(app_id);
+    let path = Path::from("apps").join(app_id);
     let locations = store.list(Some(&path)).map_ok(|m| m.location).boxed();
     store
         .delete_stream(locations)

--- a/apps/desktop/src-tauri/src/functions/app/fork.rs
+++ b/apps/desktop/src-tauri/src/functions/app/fork.rs
@@ -160,7 +160,7 @@ pub async fn summarize_local_app_bundle(
         return Err(TauriFunctionError::new("app_id is empty"));
     }
 
-    let prefix = Path::from("apps").child(app_id);
+    let prefix = Path::from("apps").join(app_id);
     let meta_store = TauriFlowLikeState::get_project_meta_store(&app_handle).await?;
     let content_store = TauriFlowLikeState::get_project_storage_store(&app_handle).await?;
 
@@ -215,7 +215,7 @@ pub async fn upload_local_app_content_bundle(
         .map_err(|e| TauriFunctionError::new(&format!("build dst content store: {e}")))?
         .as_generic();
 
-    let src_prefix = Path::from("apps").child(args.source_app_id);
+    let src_prefix = Path::from("apps").join(args.source_app_id);
     let src_prefix_str = src_prefix.as_ref().to_string();
     let dst_prefix = parse_storage_path(&args.destination_content_prefix);
 
@@ -252,7 +252,7 @@ pub async fn upload_local_app_content_bundle(
         let dst_path = relative_path
             .split('/')
             .filter(|s| !s.is_empty())
-            .fold(dst_prefix.clone(), |acc, seg| acc.child(seg));
+            .fold(dst_prefix.clone(), |acc, seg| acc.join(seg));
 
         match copy_one(
             &src_content_store,
@@ -296,7 +296,7 @@ pub async fn apply_fork_bundle(
 
     let dst_meta_store = TauriFlowLikeState::get_project_meta_store(&app_handle).await?;
     let dst_content_store = TauriFlowLikeState::get_project_storage_store(&app_handle).await?;
-    let dst_app_prefix = Path::from("apps").child(args.app_id.clone());
+    let dst_app_prefix = Path::from("apps").join(args.app_id.clone());
 
     let mut meta_blobs_written: u64 = 0;
     let mut content_objects_copied: u64 = 0;
@@ -320,7 +320,7 @@ pub async fn apply_fork_bundle(
         let dst_path = relative_path
             .split('/')
             .filter(|s| !s.is_empty())
-            .fold(dst_app_prefix.clone(), |acc, seg| acc.child(seg));
+            .fold(dst_app_prefix.clone(), |acc, seg| acc.join(seg));
         let dst_store = if is_content_blob_path(&relative_path) {
             &dst_content_store
         } else {
@@ -401,7 +401,7 @@ pub async fn apply_fork_bundle(
         let dst_path = translated
             .split('/')
             .filter(|s| !s.is_empty())
-            .fold(dst_app_prefix.clone(), |acc, seg| acc.child(seg));
+            .fold(dst_app_prefix.clone(), |acc, seg| acc.join(seg));
 
         match copy_one(
             &src_content_store,
@@ -501,10 +501,7 @@ async fn open_local_project_db(
     let write_options = config.callbacks.lance_write_options.clone();
     drop(config);
 
-    let db_dir = Path::from("apps")
-        .child(app_id)
-        .child("storage")
-        .child("db");
+    let db_dir = Path::from("apps").join(app_id).join("storage").join("db");
     let connection = builder(db_dir)
         .execute()
         .await
@@ -675,7 +672,7 @@ fn is_missing_prefix_error(error: &impl std::fmt::Display) -> bool {
 fn parse_storage_path(raw: &str) -> Path {
     raw.split('/')
         .filter(|s| !s.is_empty())
-        .fold(Path::default(), |acc, seg| acc.child(seg))
+        .fold(Path::default(), |acc, seg| acc.join(seg))
 }
 
 fn relative_to_prefix(path: &str, prefix: &str) -> Option<String> {

--- a/apps/desktop/src-tauri/src/functions/app/graph.rs
+++ b/apps/desktop/src-tauri/src/functions/app/graph.rs
@@ -30,20 +30,17 @@ pub(crate) async fn graph_connection(
     user_scoped: bool,
 ) -> flow_like_types::Result<Connection> {
     let flow_like_state = TauriFlowLikeState::construct(app_handle).await?;
-    let project_db_dir = Path::from("apps")
-        .child(app_id)
-        .child("storage")
-        .child("db");
+    let project_db_dir = Path::from("apps").join(app_id).join("storage").join("db");
 
     let builder = if user_scoped {
         let sub = current_user_sub(app_handle)
             .await
             .map_err(|e| flow_like_types::anyhow!(e.to_string()))?;
         let user_db_dir = Path::from("users")
-            .child(sub)
-            .child("apps")
-            .child(app_id)
-            .child("db");
+            .join(sub)
+            .join("apps")
+            .join(app_id)
+            .join("db");
         flow_like_state
             .config
             .read()

--- a/apps/desktop/src-tauri/src/functions/app/tables.rs
+++ b/apps/desktop/src-tauri/src/functions/app/tables.rs
@@ -66,10 +66,7 @@ async fn db_connection_handle(
     sub: Option<String>,
 ) -> flow_like_types::Result<Connection> {
     let flow_like_state = TauriFlowLikeState::construct(app_handle).await?;
-    let project_db_dir = Path::from("apps")
-        .child(app_id)
-        .child("storage")
-        .child("db");
+    let project_db_dir = Path::from("apps").join(app_id).join("storage").join("db");
     let db = if let Some(credentials) = &credentials {
         if user_scoped {
             let sub = sub.ok_or_else(|| {
@@ -89,10 +86,10 @@ async fn db_connection_handle(
                 .map_err(|e| flow_like_types::anyhow!(e.to_string()))?,
         };
         let user_db_dir = Path::from("users")
-            .child(sub)
-            .child("apps")
-            .child(app_id)
-            .child("db");
+            .join(sub)
+            .join("apps")
+            .join(app_id)
+            .join("db");
         flow_like_state
             .config
             .read()

--- a/apps/desktop/src-tauri/src/functions/flow/run.rs
+++ b/apps/desktop/src-tauri/src/functions/flow/run.rs
@@ -946,7 +946,7 @@ async fn execute_prepared(
             let db_fn = db_fn
                 .as_ref()
                 .ok_or_else(|| flow_like_types::anyhow!("No log database configured"))?;
-            let base_path = Path::from("runs").child(app_id).child(board_id);
+            let base_path = Path::from("runs").join(app_id).join(board_id);
             let db = flow_like_state
                 .with_lance_session(db_fn(base_path.clone()))
                 .execute()
@@ -1174,7 +1174,7 @@ pub(crate) async fn open_runs_db(
     let db_fn = db
         .as_ref()
         .ok_or_else(|| flow_like_types::anyhow!("No log database configured"))?;
-    let base_path = Path::from("runs").child(app_id).child(board_id);
+    let base_path = Path::from("runs").join(app_id).join(board_id);
     db_fn(base_path.clone())
         .execute()
         .await

--- a/packages/api/src/compilation/dispatch.rs
+++ b/packages/api/src/compilation/dispatch.rs
@@ -905,12 +905,12 @@ pub async fn build_compilation_job(
     let mut targets = Vec::with_capacity(raw_targets.len());
 
     let base = Path::from(WASM_COMPILED_PATH)
-        .child(params.package_id.as_str())
-        .child(params.version.as_str());
+        .join(params.package_id.as_str())
+        .join(params.version.as_str());
 
     for t in &raw_targets {
-        let cwasm_path = base.child(format!("{}.cwasm", t.platform_key));
-        let checksum_path = base.child(format!("{}.cwasm.b3", t.platform_key));
+        let cwasm_path = base.clone().join(format!("{}.cwasm", t.platform_key));
+        let checksum_path = base.clone().join(format!("{}.cwasm.b3", t.platform_key));
 
         let cwasm_upload_url = meta_bucket
             .sign("PUT", &cwasm_path, Duration::from_secs(URL_TTL_SECS))

--- a/packages/api/src/deletion/external/app.rs
+++ b/packages/api/src/deletion/external/app.rs
@@ -117,8 +117,8 @@ pub async fn delete_storage_prefixes(
     let credentials = state.master_credentials().await?;
     let meta = credentials.to_store(true).await?.as_generic();
     let content = credentials.to_store(false).await?.as_generic();
-    let app_prefix = Path::from("apps").child(app_id);
-    let media_prefix = Path::from("media").child("apps").child(app_id);
+    let app_prefix = Path::from("apps").join(app_id);
+    let media_prefix = Path::from("media").join("apps").join(app_id);
     for (store, prefix, label) in [
         (&meta, &app_prefix, "meta"),
         (&content, &app_prefix, "content"),

--- a/packages/api/src/deletion/external/bit.rs
+++ b/packages/api/src/deletion/external/bit.rs
@@ -14,7 +14,7 @@ pub async fn delete_cdn_artifact(state: &AppState, bit_id: &str) -> Result<(), A
     let Some(hash) = bit.hash.filter(|hash| !hash.is_empty()) else {
         return Ok(());
     };
-    let path = Path::from("bits").child(hash.as_str());
+    let path = Path::from("bits").join(hash.as_str());
     match state.cdn_bucket.as_generic().delete(&path).await {
         Ok(()) => Ok(()),
         Err(flow_like_storage::object_store::Error::NotFound { .. }) => Ok(()),

--- a/packages/api/src/deletion/external/course.rs
+++ b/packages/api/src/deletion/external/course.rs
@@ -14,6 +14,6 @@ pub async fn delete_media(
 ) -> Result<Flow, ApiError> {
     let credentials = state.master_credentials().await?;
     let content = credentials.to_store(false).await?.as_generic();
-    let prefix = Path::from("media").child("courses").child(course_id);
+    let prefix = Path::from("media").join("courses").join(course_id);
     delete_prefix(&content, &prefix, "course media", pass).await
 }

--- a/packages/api/src/deletion/external/template.rs
+++ b/packages/api/src/deletion/external/template.rs
@@ -33,9 +33,9 @@ pub async fn delete_storage(
 
     let credentials = state.master_credentials().await?;
     let meta = credentials.to_store(true).await?.as_generic();
-    let app_dir = Path::from("apps").child(row.app_id);
+    let app_dir = Path::from("apps").join(row.app_id);
 
-    let board = app_dir.child(format!("{template_id}.template"));
+    let board = app_dir.clone().join(format!("{template_id}.template"));
     match meta.delete(&board).await {
         Ok(()) | Err(ObjectStoreError::NotFound { .. }) => {}
         Err(error) => {

--- a/packages/api/src/deletion/external/wasm_package.rs
+++ b/packages/api/src/deletion/external/wasm_package.rs
@@ -27,22 +27,22 @@ pub async fn delete_artifacts(
         (
             &content,
             "wasm",
-            Path::from(WASM_PACKAGES_PATH).child(package_id),
+            Path::from(WASM_PACKAGES_PATH).join(package_id),
         ),
         (
             &content,
             "widget bundles",
-            Path::from(WIDGET_BUNDLES_PATH).child(package_id),
+            Path::from(WIDGET_BUNDLES_PATH).join(package_id),
         ),
         (
             &content,
             "widget assets",
-            Path::from(WIDGET_ASSETS_PATH).child(package_id),
+            Path::from(WIDGET_ASSETS_PATH).join(package_id),
         ),
         (
             &meta,
             "compiled wasm",
-            Path::from(WASM_COMPILED_PATH).child(package_id),
+            Path::from(WASM_COMPILED_PATH).join(package_id),
         ),
     ] {
         if delete_prefix(store, &prefix, label, pass).await? == Flow::Suspend {

--- a/packages/api/src/execution/compiled_artifacts.rs
+++ b/packages/api/src/execution/compiled_artifacts.rs
@@ -71,7 +71,7 @@ pub async fn ensure_compiled_artifact(
     let registry = state.artifact_registry(wasm_packages).await?;
     let fingerprint = registry.fingerprint();
     let fingerprint_hex = blake3::Hash::from_bytes(fingerprint).to_hex();
-    let storage_root = Path::from("apps").child(app_id.to_string());
+    let storage_root = Path::from("apps").join(app_id.to_string());
     let meta_store = state.meta_bucket.as_generic();
 
     if expected_etag.is_some() {

--- a/packages/api/src/execution/regression/mod.rs
+++ b/packages/api/src/execution/regression/mod.rs
@@ -215,7 +215,7 @@ pub(crate) async fn open_runs_db(
         .map_err(|e| {
             ApiError::internal_error(anyhow!("Failed to create logs db builder: {}", e))
         })?;
-    let base_path = StoragePath::from("runs").child(app_id).child(board_id);
+    let base_path = StoragePath::from("runs").join(app_id).join(board_id);
     let db = logs_db_builder(base_path.clone())
         .execute()
         .await

--- a/packages/api/src/routes/admin/bit/delete_bit.rs
+++ b/packages/api/src/routes/admin/bit/delete_bit.rs
@@ -42,7 +42,7 @@ pub async fn delete_bit(
         let bit: Bit = bit.into();
         if !bit.hash.is_empty() {
             let path =
-                flow_like_storage::object_store::path::Path::from("bits").child(bit.hash.clone());
+                flow_like_storage::object_store::path::Path::from("bits").join(bit.hash.clone());
             cdn_bucket.as_generic().delete(&path).await?;
         }
         bits.push(bit);

--- a/packages/api/src/routes/admin/bit/upsert_bit.rs
+++ b/packages/api/src/routes/admin/bit/upsert_bit.rs
@@ -408,7 +408,7 @@ async fn download_and_hash(
     let store = state.cdn_bucket.clone();
 
     let old_location = flow_like_storage::object_store::path::Path::from("bits")
-        .child(bit.hash.clone().unwrap_or(bit.id.clone()));
+        .join(bit.hash.clone().unwrap_or(bit.id.clone()));
     let _delete = store.as_generic().delete(&old_location).await;
 
     let url = match bit.download_link {
@@ -466,7 +466,7 @@ async fn download_and_hash(
             .await;
     }
 
-    let path = flow_like_storage::object_store::path::Path::from("bits").child(e_tag.clone());
+    let path = flow_like_storage::object_store::path::Path::from("bits").join(e_tag.clone());
 
     // For ranged downloads
     const CHUNK_SIZE: usize = 50 * 1024 * 1024; // 50MB chunks

--- a/packages/api/src/routes/admin/packages/ensure_wasm_artifacts.rs
+++ b/packages/api/src/routes/admin/packages/ensure_wasm_artifacts.rs
@@ -53,11 +53,11 @@ fn current_linux_x86_64_platform() -> String {
 
 fn artifact_paths(package_id: &str, version: &str, target_platform: &str) -> (Path, Path) {
     let base = Path::from(WASM_COMPILED_PATH)
-        .child(package_id)
-        .child(version);
+        .join(package_id)
+        .join(version);
     (
-        base.child(format!("{}.cwasm", target_platform)),
-        base.child(format!("{}.cwasm.b3", target_platform)),
+        base.clone().join(format!("{}.cwasm", target_platform)),
+        base.join(format!("{}.cwasm.b3", target_platform)),
     )
 }
 

--- a/packages/api/src/routes/admin/profiles/get_signed_profile_img_url.rs
+++ b/packages/api/src/routes/admin/profiles/get_signed_profile_img_url.rs
@@ -45,7 +45,7 @@ pub async fn get_signed_profile_img_url(
     let id = create_id();
     let cdn_bucket = state.cdn_bucket.clone();
     let path = flow_like_storage::object_store::path::Path::from("profiles")
-        .child(format!("{id}.{extension}"));
+        .join(format!("{id}.{extension}"));
 
     let url = cdn_bucket
         .sign("PUT", &path, Duration::from_secs(60 * 60))

--- a/packages/api/src/routes/admin/publication/get_requests.rs
+++ b/packages/api/src/routes/admin/publication/get_requests.rs
@@ -282,13 +282,13 @@ pub async fn get_requests(
 
         // Presign icon/thumbnail if they are storage keys (not already URLs)
         let prefix = flow_like_storage::Path::from("media")
-            .child("apps")
-            .child(app_id.clone());
+            .join("apps")
+            .join(app_id.clone());
         if let Some(ref icon) = app_icon
             && !icon.starts_with("http://")
             && !icon.starts_with("https://")
         {
-            let icon_path = prefix.child(format!("{icon}.webp"));
+            let icon_path = prefix.clone().join(format!("{icon}.webp"));
             if let Ok(url) = store
                 .sign("GET", &icon_path, std::time::Duration::from_secs(60 * 60))
                 .await
@@ -300,7 +300,7 @@ pub async fn get_requests(
             && !thumb.starts_with("http://")
             && !thumb.starts_with("https://")
         {
-            let thumb_path = prefix.child(format!("{thumb}.webp"));
+            let thumb_path = prefix.join(format!("{thumb}.webp"));
             if let Ok(url) = store
                 .sign("GET", &thumb_path, std::time::Duration::from_secs(60 * 60))
                 .await

--- a/packages/api/src/routes/app/board/get_runs.rs
+++ b/packages/api/src/routes/app/board/get_runs.rs
@@ -66,7 +66,7 @@ async fn hydrate_node_summaries(
         .scoped_credentials(sub, app_id, CredentialsAccess::ReadLogs)
         .await?;
     let logs_db_builder = credentials.into_shared_credentials().to_logs_db_builder()?;
-    let base_path = StoragePath::from("runs").child(app_id).child(board_id);
+    let base_path = StoragePath::from("runs").join(app_id).join(board_id);
     let db = logs_db_builder(base_path).execute().await?;
     let table = db.open_table("runs").execute().await?;
 

--- a/packages/api/src/routes/app/board/query_logs.rs
+++ b/packages/api/src/routes/app/board/query_logs.rs
@@ -71,8 +71,8 @@ pub async fn query_logs(
     })?;
 
     let base_path = StoragePath::from("runs")
-        .child(app_id.as_str())
-        .child(board_id.as_str());
+        .join(app_id.as_str())
+        .join(board_id.as_str());
 
     let db = logs_db_builder(base_path.clone())
         .execute()

--- a/packages/api/src/routes/app/connection/graph.rs
+++ b/packages/api/src/routes/app/connection/graph.rs
@@ -449,8 +449,8 @@ pub(crate) async fn presign_media_under(
                     ..Default::default()
                 };
                 let prefix = FlowPath::from("media")
-                    .child(segment.to_string())
-                    .child(entity_id.clone());
+                    .join(segment.to_string())
+                    .join(entity_id.clone());
                 metadata.presign(prefix, store).await;
                 (entity_id.clone(), (metadata.icon, metadata.thumbnail))
             }

--- a/packages/api/src/routes/app/data/paths.rs
+++ b/packages/api/src/routes/app/data/paths.rs
@@ -14,11 +14,11 @@
 use flow_like_storage::Path;
 
 pub fn app_upload_base(app_id: &str) -> Path {
-    Path::from("apps").child(app_id).child("upload")
+    Path::from("apps").join(app_id).join("upload")
 }
 
 pub fn user_upload_base(sub: &str, app_id: &str) -> Path {
-    Path::from("users").child(sub).child("apps").child(app_id)
+    Path::from("users").join(sub).join("apps").join(app_id)
 }
 
 pub fn resolve_app_upload(app_id: &str, prefix: &str) -> Path {
@@ -35,7 +35,7 @@ fn append(base: Path, relative: &str) -> Path {
     relative
         .split('/')
         .filter(|segment| !segment.is_empty())
-        .fold(base, |path, segment| path.child(segment))
+        .fold(base, |path, segment| path.join(segment))
 }
 
 fn strip_app_layout(prefix: &str) -> Option<&str> {

--- a/packages/api/src/routes/app/events/get_event_runs.rs
+++ b/packages/api/src/routes/app/events/get_event_runs.rs
@@ -238,8 +238,8 @@ pub async fn get_event_runs(
     // one board with an unreadable log store must not hide the others.
     for board_id in &board_ids {
         let base_path = StoragePath::from("runs")
-            .child(app_id.as_str())
-            .child(board_id.as_str());
+            .join(app_id.as_str())
+            .join(board_id.as_str());
         let db = match logs_db_builder(base_path.clone()).execute().await {
             Ok(db) => db,
             Err(error) => {

--- a/packages/api/src/routes/app/events/page_trigger.rs
+++ b/packages/api/src/routes/app/events/page_trigger.rs
@@ -889,7 +889,7 @@ mod tests {
     fn empty_page_execution() -> PrerunPageExecution {
         let board = Board::new_detached(
             Some("board-1".into()),
-            flow_like_storage::Path::from("apps").child("app-1"),
+            flow_like_storage::Path::from("apps").join("app-1"),
         );
         let page = flow_like::a2ui::Page::new("page-1", "Page", "/");
         PrerunPageExecution::from_page(&board, &page).unwrap()
@@ -1075,7 +1075,7 @@ mod tests {
     fn contract_with_revision(target: &ResolvedTarget, revision: &str) -> ResolvedPageContract {
         let board = Board::new_detached(
             Some(target.board_id.clone()),
-            flow_like_storage::Path::from("apps").child("app-1"),
+            flow_like_storage::Path::from("apps").join("app-1"),
         );
         let page_id = target.default_page_id.as_deref().unwrap();
         let page = flow_like::a2ui::Page::new(page_id, "Page", "/");

--- a/packages/api/src/routes/app/internal/get_apps.rs
+++ b/packages/api/src/routes/app/internal/get_apps.rs
@@ -83,8 +83,8 @@ pub async fn get_apps(
         {
             let mut metadata = Metadata::from(meta.clone());
             let prefix = flow_like_storage::Path::from("media")
-                .child("apps")
-                .child(app_model.id.clone());
+                .join("apps")
+                .join(app_model.id.clone());
             metadata.presign(prefix, &store).await;
             Some(metadata)
         } else {

--- a/packages/api/src/routes/app/internal/get_detail.rs
+++ b/packages/api/src/routes/app/internal/get_detail.rs
@@ -137,7 +137,7 @@ pub async fn get_detail(
         let mut metadata = Metadata::from(meta_model);
         let master_store = state.master_credentials().await?;
         let store = master_store.to_store(false).await?;
-        let prefix = FlowPath::from("media").child("apps").child(app_id.clone());
+        let prefix = FlowPath::from("media").join("apps").join(app_id.clone());
         metadata.presign(prefix, &store).await;
         Some(metadata)
     } else {

--- a/packages/api/src/routes/app/internal/search_apps.rs
+++ b/packages/api/src/routes/app/internal/search_apps.rs
@@ -138,8 +138,8 @@ pub async fn search_apps(
         {
             let mut metadata = Metadata::from(meta.clone());
             let prefix = flow_like_storage::Path::from("media")
-                .child("apps")
-                .child(app_model.id.clone());
+                .join("apps")
+                .join(app_model.id.clone());
             metadata.presign(prefix, &store).await;
             Some(metadata)
         } else {

--- a/packages/api/src/routes/app/internal/search_templates.rs
+++ b/packages/api/src/routes/app/internal/search_templates.rs
@@ -176,8 +176,8 @@ pub async fn search_templates(
             Some(meta) => {
                 let mut metadata = Metadata::from(meta.clone());
                 let prefix = flow_like_storage::Path::from("media")
-                    .child("apps")
-                    .child(template_model.app_id.clone());
+                    .join("apps")
+                    .join(template_model.app_id.clone());
                 metadata.presign(prefix, &store).await;
                 Some(metadata)
             }

--- a/packages/api/src/routes/app/meta.rs
+++ b/packages/api/src/routes/app/meta.rs
@@ -104,11 +104,11 @@ impl MetaMode {
     pub fn media_prefix(&self, app_id: &str) -> FlowPath {
         match self {
             MetaMode::Group(group_id) => FlowPath::from("media")
-                .child("groups")
-                .child(group_id.clone()),
+                .join("groups")
+                .join(group_id.clone()),
             _ => FlowPath::from("media")
-                .child("apps")
-                .child(app_id.to_string()),
+                .join("apps")
+                .join(app_id.to_string()),
         }
     }
 

--- a/packages/api/src/routes/app/meta/push_media.rs
+++ b/packages/api/src/routes/app/meta/push_media.rs
@@ -109,13 +109,13 @@ pub async fn push_media(
     let master_store = master_store.to_store(false).await?;
 
     if let Some(replaced) = replaced {
-        let path = media_prefix.child(format!("{}.webp", replaced));
+        let path = media_prefix.clone().join(format!("{}.webp", replaced));
         if let Err(err) = master_store.as_generic().delete(&path).await {
             tracing::error!("Failed to delete replaced media at {}: {:?}", path, err);
         }
     }
 
-    let path = media_prefix.child(item_name.clone());
+    let path = media_prefix.join(item_name.clone());
     let signed_url = master_store
         .sign("PUT", &path, Duration::from_secs(60 * 60 * 24))
         .await

--- a/packages/api/src/routes/app/meta/remove_media.rs
+++ b/packages/api/src/routes/app/meta/remove_media.rs
@@ -58,7 +58,7 @@ pub async fn remove_media(
     let language = query.language.clone().unwrap_or_else(|| "en".to_string());
     let media_path = mode
         .media_prefix(&app_id)
-        .child(format!("{}.webp", media_id));
+        .join(format!("{}.webp", media_id));
     let mode = Arc::new(mode);
     let query = Arc::new(query);
 

--- a/packages/api/src/routes/app/prerun_shared.rs
+++ b/packages/api/src/routes/app/prerun_shared.rs
@@ -374,7 +374,7 @@ pub async fn ensure_versioned_page_prerun_manifest(
         &requested_page.id,
         &page_revision,
     );
-    let storage_root = Path::from("apps").child(app_id.to_string());
+    let storage_root = Path::from("apps").join(app_id.to_string());
     let path = version_page_manifest_path(
         &storage_root,
         board_id,
@@ -465,7 +465,7 @@ pub async fn ensure_draft_board_snapshot(
         }
     }
 
-    let storage_root = Path::from("apps").child(app_id.to_string());
+    let storage_root = Path::from("apps").join(app_id.to_string());
     let source_path = Board::proto_path(&storage_root, board_id, None);
     let source = meta_store
         .get_opts(
@@ -540,7 +540,7 @@ pub async fn load_exact_prerun_manifest(
                         .master_state(state)
                         .await
                         .map_err(ApiError::internal_error)?;
-                    let storage_root = Path::from("apps").child(app_id.to_string());
+                    let storage_root = Path::from("apps").join(app_id.to_string());
                     Board::from_loaded_proto(proto, storage_root, app_state)
                         .await
                         .map_err(ApiError::internal_error)
@@ -729,7 +729,7 @@ mod draft_manifest_cache_tests {
 
     #[test]
     fn page_manifest_read_requires_the_exact_board_authority_and_page() {
-        let board = Board::new_detached(Some("board-1".into()), Path::from("apps").child("app-1"));
+        let board = Board::new_detached(Some("board-1".into()), Path::from("apps").join("app-1"));
         let authority = PrerunManifest::from_board(&board);
         let page = Page::new("page-1", "Page", "/");
         let candidate = PrerunManifest::from_board_and_page(&board, &page).unwrap();
@@ -765,7 +765,7 @@ mod draft_manifest_cache_tests {
     async fn fresh_lambda_cache_reads_etag_manifest_from_shared_storage() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let mut persisted_board =
-            Board::new_detached(Some("board-1".into()), Path::from("apps").child("app-1"));
+            Board::new_detached(Some("board-1".into()), Path::from("apps").join("app-1"));
         persisted_board.execution_mode = flow_like::flow::board::ExecutionMode::Local;
         let persisted = PrerunManifest::from_board(&persisted_board);
         let path = draft_manifest_path("app-1", "board-1", "etag-1");
@@ -781,7 +781,7 @@ mod draft_manifest_cache_tests {
 
         let rebuilt = PrerunManifest::from_board(&Board::new_detached(
             Some("board-1".into()),
-            Path::from("apps").child("app-1"),
+            Path::from("apps").join("app-1"),
         ));
         assert_eq!(loaded.as_ref(), &persisted);
         assert_ne!(loaded.signature, rebuilt.signature);
@@ -817,7 +817,7 @@ mod draft_manifest_cache_tests {
     async fn swept_etag_manifest_is_rebuilt_from_the_exact_board_snapshot() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let mut board =
-            Board::new_detached(Some("board-1".into()), Path::from("apps").child("app-1"));
+            Board::new_detached(Some("board-1".into()), Path::from("apps").join("app-1"));
         board.execution_mode = flow_like::flow::board::ExecutionMode::Local;
         let authority = PrerunManifest::from_board(&board);
         flow_like::utils::compression::compress_to_file(
@@ -875,7 +875,7 @@ mod draft_manifest_cache_tests {
 
     #[test]
     fn exact_board_source_if_match_race_maps_to_a_client_actionable_status() {
-        let path = Path::from("apps").child("app-1").child("board-1.board");
+        let path = Path::from("apps").join("app-1").join("board-1.board");
 
         let stale = exact_board_source_read_error(
             &path,
@@ -904,7 +904,7 @@ mod draft_manifest_cache_tests {
     #[tokio::test]
     async fn board_authority_loader_rejects_a_page_aware_artifact() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let board = Board::new_detached(Some("board-1".into()), Path::from("apps").child("app-1"));
+        let board = Board::new_detached(Some("board-1".into()), Path::from("apps").join("app-1"));
         let manifest =
             PrerunManifest::from_board_and_page(&board, &Page::new("page-1", "Page", "/")).unwrap();
         let path = draft_manifest_path("app-1", "board-1", "etag-1");
@@ -922,7 +922,7 @@ mod draft_manifest_cache_tests {
     #[tokio::test]
     async fn cached_page_manifest_is_republished_after_shared_deletion() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let board = Board::new_detached(Some("board-1".into()), Path::from("apps").child("app-1"));
+        let board = Board::new_detached(Some("board-1".into()), Path::from("apps").join("app-1"));
         let cached =
             PrerunManifest::from_board_and_page(&board, &Page::new("page-1", "Page", "/")).unwrap();
         let path =
@@ -942,7 +942,7 @@ mod draft_manifest_cache_tests {
     #[tokio::test]
     async fn cached_version_page_manifest_is_republished_after_shared_deletion() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let storage_root = Path::from("apps").child("app-1");
+        let storage_root = Path::from("apps").join("app-1");
         let board = Board::new_detached(Some("board-1".into()), storage_root.clone());
         let page = Page::new("page-1", "Page", "/");
         let cached = PrerunManifest::from_board_and_page(&board, &page).unwrap();
@@ -964,9 +964,9 @@ mod draft_manifest_cache_tests {
     #[tokio::test]
     async fn cached_version_manifest_is_republished_after_shared_deletion() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let board = Board::new_detached(Some("board-1".into()), Path::from("apps").child("app-1"));
+        let board = Board::new_detached(Some("board-1".into()), Path::from("apps").join("app-1"));
         let cached = PrerunManifest::from_board(&board);
-        let storage_root = Path::from("apps").child("app-1");
+        let storage_root = Path::from("apps").join("app-1");
         let path = manifest_path(&storage_root, "board-1", (1, 2, 3));
         assert!(persist_prerun_manifest(store.as_ref(), &path, &cached).await);
         store.delete(&path).await.unwrap();
@@ -983,7 +983,7 @@ mod draft_manifest_cache_tests {
     #[tokio::test]
     async fn pinned_pages_publish_to_disjoint_keys_without_changing_callback_authority() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let storage_root = Path::from("apps").child("app-1");
+        let storage_root = Path::from("apps").join("app-1");
         let mut board = Board::new_detached(Some("board-1".into()), storage_root.clone());
         board.page_ids = vec!["page-1".into(), "page-2".into()];
         let authority = PrerunManifest::from_board(&board);
@@ -1041,7 +1041,7 @@ mod draft_manifest_cache_tests {
     #[tokio::test]
     async fn format_scoped_version_manifest_isolated_from_legacy_writers() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let storage_root = Path::from("apps").child("app-1");
+        let storage_root = Path::from("apps").join("app-1");
         let current_path = manifest_path(&storage_root, "board-1", (1, 2, 3));
         let legacy_path = legacy_manifest_path(&storage_root, "board-1", (1, 2, 3));
         assert_ne!(current_path, legacy_path);
@@ -1069,7 +1069,7 @@ mod draft_manifest_cache_tests {
     #[tokio::test]
     async fn version_manifest_reader_reports_legacy_fallback_on_current_miss() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let storage_root = Path::from("apps").child("app-1");
+        let storage_root = Path::from("apps").join("app-1");
         let current_path = manifest_path(&storage_root, "board-1", (1, 2, 3));
         let legacy_path = legacy_manifest_path(&storage_root, "board-1", (1, 2, 3));
         let legacy =
@@ -1090,7 +1090,7 @@ mod draft_manifest_cache_tests {
     #[tokio::test]
     async fn version_board_authority_rejects_page_dependent_bytes() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let storage_root = Path::from("apps").child("app-1");
+        let storage_root = Path::from("apps").join("app-1");
         let board = Board::new_detached(Some("board-1".into()), storage_root.clone());
         let page_manifest =
             PrerunManifest::from_board_and_page(&board, &Page::new("page-1", "Page", "/")).unwrap();
@@ -1119,7 +1119,7 @@ pub async fn load_prerun_manifest(
     board_id: &str,
     version: Option<(u32, u32, u32)>,
 ) -> Result<Arc<PrerunManifest>, ApiError> {
-    let storage_root = Path::from("apps").child(app_id.to_string());
+    let storage_root = Path::from("apps").join(app_id.to_string());
     let meta_store = state.meta_bucket.as_generic();
 
     let Some(version) = version else {

--- a/packages/api/src/routes/app/template/get_templates.rs
+++ b/packages/api/src/routes/app/template/get_templates.rs
@@ -87,8 +87,8 @@ pub async fn get_templates(
         {
             let mut metadata = Metadata::from(meta.clone());
             let prefix = flow_like_storage::Path::from("media")
-                .child("apps")
-                .child(template_model.app_id.clone());
+                .join("apps")
+                .join(template_model.app_id.clone());
             metadata.presign(prefix, &store).await;
             templates.push((app_id.clone(), template_model.id.clone(), metadata));
         }

--- a/packages/api/src/routes/app/widget/get_widgets.rs
+++ b/packages/api/src/routes/app/widget/get_widgets.rs
@@ -75,8 +75,8 @@ pub async fn get_widgets(
         {
             let mut metadata = Metadata::from(meta.clone());
             let prefix = flow_like_storage::Path::from("media")
-                .child("apps")
-                .child(widget_model.app_id.clone());
+                .join("apps")
+                .join(widget_model.app_id.clone());
             metadata.presign(prefix, &store).await;
             widgets.push((app_id.clone(), widget_model.id.clone(), metadata));
         }

--- a/packages/api/src/routes/bit/get_bit.rs
+++ b/packages/api/src/routes/bit/get_bit.rs
@@ -101,7 +101,7 @@ pub async fn temporary_bit(bit: Bit, store: &Arc<FlowLikeStore>) -> flow_like_ty
         None => return Ok(bit),
     };
 
-    let path = flow_like_storage::object_store::path::Path::from("bits").child(name.to_string());
+    let path = flow_like_storage::object_store::path::Path::from("bits").join(name.to_string());
     let url = store
         .sign("GET", &path, Duration::from_secs(60 * 60 * 24))
         .await?;

--- a/packages/api/src/routes/course/assets.rs
+++ b/packages/api/src/routes/course/assets.rs
@@ -107,10 +107,10 @@ pub struct UpdateCourseAssetBody {
 
 pub fn course_asset_storage_path(course_id: &str, file_name: &str) -> FlowPath {
     FlowPath::from("media")
-        .child("courses")
-        .child(course_id)
-        .child("assets")
-        .child(file_name)
+        .join("courses")
+        .join(course_id)
+        .join("assets")
+        .join(file_name)
 }
 
 fn normalize_extension(extension: &str) -> Result<String, ApiError> {

--- a/packages/api/src/routes/course/courses.rs
+++ b/packages/api/src/routes/course/courses.rs
@@ -152,9 +152,9 @@ fn transformed_course_media_file_name(value: &str) -> String {
 
 fn course_media_storage_path(course_id: &str, file_name: &str) -> FlowPath {
     FlowPath::from("media")
-        .child("courses")
-        .child(course_id)
-        .child(file_name)
+        .join("courses")
+        .join(course_id)
+        .join(file_name)
 }
 
 async fn resolve_course_media_url(

--- a/packages/api/src/routes/inbound.rs
+++ b/packages/api/src/routes/inbound.rs
@@ -1306,7 +1306,7 @@ fn app_scoped_content_path(
         relative = rest.to_string();
     }
 
-    let mut path = flow_like_storage::Path::from("apps").child(app_id);
+    let mut path = flow_like_storage::Path::from("apps").join(app_id);
     if !relative.is_empty() {
         path = append_object_path_segments(path, relative.as_str());
     }
@@ -1325,7 +1325,7 @@ fn append_object_path_segments(
     value: &str,
 ) -> flow_like_storage::Path {
     for segment in value.split('/').filter(|segment| !segment.is_empty()) {
-        path = path.child(segment);
+        path = path.join(segment);
     }
     path
 }

--- a/packages/api/src/routes/profile.rs
+++ b/packages/api/src/routes/profile.rs
@@ -96,9 +96,9 @@ pub async fn sign_profile_image(
         format!("{}.webp", image_id)
     };
     let path = flow_like_storage::Path::from("media")
-        .child("users")
-        .child(sub)
-        .child(file_name);
+        .join("users")
+        .join(sub)
+        .join(file_name);
     let url = master_store
         .sign("GET", &path, Duration::from_secs(60 * 5))
         .await?;

--- a/packages/api/src/routes/profile/media.rs
+++ b/packages/api/src/routes/profile/media.rs
@@ -50,15 +50,12 @@ fn upload_stem(upload_id: &str) -> Result<&str, ApiError> {
 
 fn metadata_path(sub: &str, stem: &str) -> Path {
     Path::from("profile-media-uploads")
-        .child(sub)
-        .child(format!("{stem}.json"))
+        .join(sub)
+        .join(format!("{stem}.json"))
 }
 
 fn image_path(sub: &str, filename: &str) -> Path {
-    Path::from("media")
-        .child("users")
-        .child(sub)
-        .child(filename)
+    Path::from("media").join("users").join(sub).join(filename)
 }
 
 /// Allocate a private upload without changing the account or profile image.
@@ -78,8 +75,8 @@ fn sync_slot_path(sub: &str, scope: &str) -> Path {
         .to_hex()
         .to_string();
     Path::from("profile-media-upload-slots")
-        .child(sub)
-        .child(format!("{key}.json"))
+        .join(sub)
+        .join(format!("{key}.json"))
 }
 
 pub(crate) async fn prepare_sync_upload(

--- a/packages/api/src/routes/registry/metadata.rs
+++ b/packages/api/src/routes/registry/metadata.rs
@@ -409,8 +409,8 @@ pub async fn get_meta(
 
     // Presign icon, thumbnail and preview_media CUIDs to full URLs
     let prefix = FlowPath::from("media")
-        .child("packages")
-        .child(package_id.as_str());
+        .join("packages")
+        .join(package_id.as_str());
     if let Ok(master_creds) = state.master_credentials().await
         && let Ok(store) = master_creds.to_store(false).await
     {
@@ -418,7 +418,7 @@ pub async fn get_meta(
             && !icon.starts_with("http://")
             && !icon.starts_with("https://")
         {
-            let path = prefix.child(format!("{icon}.webp"));
+            let path = prefix.clone().join(format!("{icon}.webp"));
             if let Ok(url) = store
                 .sign_cached("GET", &path, Duration::from_secs(86400))
                 .await
@@ -430,7 +430,7 @@ pub async fn get_meta(
             && !thumb.starts_with("http://")
             && !thumb.starts_with("https://")
         {
-            let path = prefix.child(format!("{thumb}.webp"));
+            let path = prefix.clone().join(format!("{thumb}.webp"));
             if let Ok(url) = store
                 .sign_cached("GET", &path, Duration::from_secs(86400))
                 .await
@@ -441,7 +441,7 @@ pub async fn get_meta(
         if let Some(media) = &mut resp.preview_media {
             for item in media.iter_mut() {
                 if !item.starts_with("http://") && !item.starts_with("https://") {
-                    let path = prefix.child(format!("{item}.webp"));
+                    let path = prefix.clone().join(format!("{item}.webp"));
                     if let Ok(url) = store
                         .sign_cached("GET", &path, Duration::from_secs(86400))
                         .await
@@ -699,9 +699,9 @@ pub async fn push_package_media(
 
 fn package_media_path(package_id: &str, file_name: &str) -> FlowPath {
     FlowPath::from("media")
-        .child("packages")
-        .child(package_id)
-        .child(file_name)
+        .join("packages")
+        .join(package_id)
+        .join(file_name)
 }
 
 /// DELETE /registry/package/{package_id}/meta/media/{media_id}

--- a/packages/api/src/routes/registry/server.rs
+++ b/packages/api/src/routes/registry/server.rs
@@ -195,13 +195,13 @@ pub async fn unpack_widget_bundle_to_assets(
     .await??;
 
     let base = Path::from(WIDGET_ASSETS_PATH)
-        .child(package_id)
-        .child(version);
+        .join(package_id)
+        .join(version);
     let mut uploaded = 0usize;
     for (rel, data) in entries {
         let mut object_path = base.clone();
         for segment in rel.split('/') {
-            object_path = object_path.child(segment);
+            object_path = object_path.join(segment);
         }
         store
             .as_generic()
@@ -521,16 +521,16 @@ impl ServerRegistry {
     /// Get storage path for a WASM package version
     fn wasm_path(package_id: &str, version: &str) -> Path {
         Path::from(WASM_PACKAGES_PATH)
-            .child(package_id)
-            .child(version)
-            .child("node.wasm")
+            .join(package_id)
+            .join(version)
+            .join("node.wasm")
     }
 
     /// Get storage path for a widget bundle version
     fn widget_bundle_path(package_id: &str, version: &str) -> Path {
         Path::from(WIDGET_BUNDLES_PATH)
-            .child(package_id)
-            .child(format!("{}.flwb", version))
+            .join(package_id)
+            .join(format!("{}.flwb", version))
     }
 
     async fn resolve_wasm_path(
@@ -682,11 +682,11 @@ impl ServerRegistry {
     ) -> flow_like_types::Result<(String, String)> {
         let target_platform = normalize_target_platform_key(target_platform);
         let base = Path::from(WASM_COMPILED_PATH)
-            .child(package_id)
-            .child(version);
+            .join(package_id)
+            .join(version);
 
-        let cwasm_path = base.child(format!("{}.cwasm", target_platform));
-        let checksum_path = base.child(format!("{}.cwasm.b3", target_platform));
+        let cwasm_path = base.clone().join(format!("{}.cwasm", target_platform));
+        let checksum_path = base.join(format!("{}.cwasm.b3", target_platform));
 
         let cwasm_url = self
             .meta_bucket
@@ -755,10 +755,10 @@ impl ServerRegistry {
         entry_path: &str,
     ) -> flow_like_types::Result<Option<Vec<u8>>> {
         let mut path = Path::from(WIDGET_ASSETS_PATH)
-            .child(package_id)
-            .child(version);
+            .join(package_id)
+            .join(version);
         for segment in entry_path.split('/').filter(|s| !s.is_empty()) {
-            path = path.child(segment);
+            path = path.join(segment);
         }
         match self.content_bucket.as_generic().get(&path).await {
             Ok(data) => Ok(Some(data.bytes().await?.to_vec())),
@@ -2918,10 +2918,10 @@ mod tests {
             "widgets/kpi-card/contract.json",
         ] {
             let mut path = Path::from(WIDGET_ASSETS_PATH)
-                .child("com.example.w")
-                .child("1.0.0");
+                .join("com.example.w")
+                .join("1.0.0");
             for segment in entry.split('/') {
-                path = path.child(segment);
+                path = path.join(segment);
             }
             let object = store.as_generic().get(&path).await;
             assert!(object.is_ok(), "missing unpacked asset: {}", entry);

--- a/packages/api/src/routes/registry/types.rs
+++ b/packages/api/src/routes/registry/types.rs
@@ -47,12 +47,12 @@ impl MetaSummary {
     }
 
     pub async fn presign_media(&mut self, package_id: &str, store: &FlowLikeStore) {
-        let prefix = FlowPath::from("media").child("packages").child(package_id);
+        let prefix = FlowPath::from("media").join("packages").join(package_id);
         if let Some(icon) = &self.icon
             && !icon.starts_with("http://")
             && !icon.starts_with("https://")
         {
-            let path = prefix.child(format!("{icon}.webp"));
+            let path = prefix.clone().join(format!("{icon}.webp"));
             if let Ok(url) = store
                 .sign_cached("GET", &path, Duration::from_secs(86400))
                 .await
@@ -64,7 +64,7 @@ impl MetaSummary {
             && !thumb.starts_with("http://")
             && !thumb.starts_with("https://")
         {
-            let path = prefix.child(format!("{thumb}.webp"));
+            let path = prefix.join(format!("{thumb}.webp"));
             if let Ok(url) = store
                 .sign_cached("GET", &path, Duration::from_secs(86400))
                 .await

--- a/packages/api/src/routes/user.rs
+++ b/packages/api/src/routes/user.rs
@@ -57,9 +57,9 @@ pub async fn sign_avatar(
     let master_store = state.master_credentials().await?;
     let master_store = master_store.to_store(false).await?;
     let path = flow_like_storage::Path::from("media")
-        .child("users")
-        .child(sub)
-        .child(avatar_file_name(avatar_id));
+        .join("users")
+        .join(sub)
+        .join(avatar_file_name(avatar_id));
     let url = master_store
         .sign("GET", &path, std::time::Duration::from_secs(60 * 5))
         .await?;

--- a/packages/api/src/routes/user/bootstrap.rs
+++ b/packages/api/src/routes/user/bootstrap.rs
@@ -139,8 +139,8 @@ pub async fn bootstrap(
         {
             let mut metadata = Metadata::from(m.clone());
             let prefix = flow_like_storage::Path::from("media")
-                .child("apps")
-                .child(app_model.id.clone());
+                .join("apps")
+                .join(app_model.id.clone());
             metadata.presign(prefix, &store).await;
             Some(metadata)
         } else {

--- a/packages/api/src/routes/user/widgets.rs
+++ b/packages/api/src/routes/user/widgets.rs
@@ -114,8 +114,8 @@ async fn get_widgets_with_metadata(
         if let Some(meta) = find_best_metadata(&metadata, language) {
             let mut metadata = Metadata::from(meta.clone());
             let prefix = flow_like_storage::Path::from("media")
-                .child("apps")
-                .child(widget_model.app_id.clone());
+                .join("apps")
+                .join(widget_model.app_id.clone());
             metadata.presign(prefix, &store).await;
             result.push((
                 widget_model.app_id.clone(),

--- a/packages/api/src/state.rs
+++ b/packages/api/src/state.rs
@@ -1279,7 +1279,7 @@ impl State {
     ) -> flow_like_types::Result<Board> {
         let credentials = self.scoped_credentials(sub, app_id, mode).await?;
         let app_state = Arc::new(credentials.to_state(state.clone()).await?);
-        let storage_root = Path::from("apps").child(app_id.to_string());
+        let storage_root = Path::from("apps").join(app_id.to_string());
         let board = Board::load(storage_root, board_id, app_state, version).await?;
         Ok(board)
     }
@@ -1365,7 +1365,7 @@ impl State {
 
         let cached = self.board_cache.get(&cache_key);
         let store = Board::meta_store(&app_state).await?;
-        let storage_root = Path::from("apps").child(app_id.to_string());
+        let storage_root = Path::from("apps").join(app_id.to_string());
         let read = Board::load_proto_if_changed(
             store,
             &storage_root,
@@ -1462,7 +1462,7 @@ impl State {
         version: Option<(u32, u32, u32)>,
     ) -> flow_like_types::Result<Board> {
         let app_state = self.master_state(state).await?;
-        let storage_root = Path::from("apps").child(app_id.to_string());
+        let storage_root = Path::from("apps").join(app_id.to_string());
         let board = Board::load_template(storage_root, template_id, app_state, version).await?;
         Ok(board)
     }
@@ -1479,7 +1479,7 @@ impl State {
         let credentials = self.scoped_credentials(sub, app_id, mode).await?;
         let app_state = Arc::new(credentials.to_state(state.clone()).await?);
 
-        let storage_root = Path::from("apps").child(app_id.to_string());
+        let storage_root = Path::from("apps").join(app_id.to_string());
 
         let board = Board::load_template(storage_root, template_id, app_state, version).await?;
 

--- a/packages/api/src/utils/fork/cleanup.rs
+++ b/packages/api/src/utils/fork/cleanup.rs
@@ -54,7 +54,7 @@ pub async fn find_orphan_app_prefixes(state: &AppState) -> Result<Vec<OrphanPref
         .as_generic();
 
     let apps_prefix = Path::from("apps");
-    let media_prefix = Path::from("media").child("apps");
+    let media_prefix = Path::from("media").join("apps");
     let mut counters: HashMap<String, (u64, u64)> = HashMap::new();
     tally_prefix(&meta_store, &apps_prefix, &mut counters).await?;
     tally_prefix(&content_store, &apps_prefix, &mut counters).await?;
@@ -135,8 +135,8 @@ pub async fn delete_orphan_app_prefix(state: &AppState, app_id: &str) -> Result<
         .map_err(ApiError::internal_error)?
         .as_generic();
 
-    let app_prefix = Path::from("apps").child(app_id.to_string());
-    let media_prefix = Path::from("media").child("apps").child(app_id.to_string());
+    let app_prefix = Path::from("apps").join(app_id.to_string());
+    let media_prefix = Path::from("media").join("apps").join(app_id.to_string());
     let mut deleted = 0u64;
     for (store, prefix, label) in [
         (&meta_store, &app_prefix, "orphan meta prefix"),

--- a/packages/api/src/utils/fork/job.rs
+++ b/packages/api/src/utils/fork/job.rs
@@ -739,15 +739,15 @@ async fn copy_content(
     let mirrors: [(&str, Path, Path, bool, bool); 3] = [
         (
             "upload storage",
-            ctx.src_prefix.child("upload"),
-            ctx.dst_prefix.child("upload"),
+            ctx.src_prefix.clone().join("upload"),
+            ctx.dst_prefix.clone().join("upload"),
             ctx.policy.files,
             false,
         ),
         (
             "app storage",
-            ctx.src_prefix.child("storage"),
-            ctx.dst_prefix.child("storage"),
+            ctx.src_prefix.clone().join("storage"),
+            ctx.dst_prefix.clone().join("storage"),
             true,
             true,
         ),

--- a/packages/api/src/utils/fork/mod.rs
+++ b/packages/api/src/utils/fork/mod.rs
@@ -314,7 +314,7 @@ pub async fn compute_offline_fork_bundle(
     let src_meta_store = credentials.to_store(true).await?.as_generic();
     let src_content_store = credentials.to_store(false).await?.as_generic();
 
-    let src_prefix = Path::from("apps").child(src_app_id.to_string());
+    let src_prefix = Path::from("apps").join(src_app_id.to_string());
     let new_app_id = ids::fresh_seed();
 
     // ---- 1. Load manifest from storage, overlay DB row -------------
@@ -325,10 +325,12 @@ pub async fn compute_offline_fork_bundle(
     // `price`, `version`, `execution_mode`, `allow_forking`, etc. can
     // be arbitrarily stale. Overlay the DB row's authoritative values
     // before remap so the bundle ships current state to the desktop.
-    let mut manifest_proto: proto::App =
-        from_compressed(src_meta_store.clone(), src_prefix.child("manifest.app"))
-            .await
-            .map_err(|e| ApiError::internal_error(anyhow!("read source manifest: {e}")))?;
+    let mut manifest_proto: proto::App = from_compressed(
+        src_meta_store.clone(),
+        src_prefix.clone().join("manifest.app"),
+    )
+    .await
+    .map_err(|e| ApiError::internal_error(anyhow!("read source manifest: {e}")))?;
     overlay_app_row_into_manifest(state, src_app_id, &mut manifest_proto).await?;
 
     // Owner-defined policy, loaded server-side. The desktop is told what
@@ -447,7 +449,7 @@ pub async fn compute_offline_fork_bundle(
         .iter()
         .filter(|_| policy.flows)
     {
-        let board_path = src_prefix.child(format!("{}.board", src_board_id));
+        let board_path = src_prefix.clone().join(format!("{}.board", src_board_id));
         let mut board_proto: proto::Board = match from_compressed::<proto::Board>(
             src_meta_store.clone(),
             board_path,
@@ -726,9 +728,10 @@ pub async fn compute_offline_fork_bundle(
         }
         let dst_board_id = maps.translate_board(src_board_id);
         let src_versioned_path = src_prefix
-            .child("versions")
-            .child(src_board_id.clone())
-            .child(format!("{}_{}_{}.board", version.0, version.1, version.2));
+            .clone()
+            .join("versions")
+            .join(src_board_id.clone())
+            .join(format!("{}_{}_{}.board", version.0, version.1, version.2));
         let board_proto: proto::Board = match from_compressed::<proto::Board>(
             src_meta_store.clone(),
             src_versioned_path,
@@ -788,7 +791,7 @@ pub async fn compute_offline_fork_bundle(
         }
     }
     for (src_widget_id, new_widget_id) in maps.widgets.clone().iter().filter(|_| policy.widgets) {
-        let src_path = src_prefix.child(format!("{}.widget", src_widget_id));
+        let src_path = src_prefix.clone().join(format!("{}.widget", src_widget_id));
         let mut widget: flow_like_types::Value =
             match from_compressed_json(src_meta_store.clone(), src_path).await {
                 Ok(w) => w,
@@ -853,7 +856,9 @@ pub async fn compute_offline_fork_bundle(
             let page_id = maps.mint(src_page_id);
             maps.pages.entry(src_page_id.clone()).or_insert(page_id);
         }
-        let src_path = src_prefix.child(format!("{}.template", src_template_id));
+        let src_path = src_prefix
+            .clone()
+            .join(format!("{}.template", src_template_id));
         let board_proto: proto::Board =
             match from_compressed::<proto::Board>(src_meta_store.clone(), src_path).await {
                 Ok(b) => b,
@@ -1379,8 +1384,8 @@ async fn append_media_blobs_from_store(
     use base64::Engine as _;
 
     let src_media_dir = Path::from("media")
-        .child("apps")
-        .child(src_app_id.to_string());
+        .join("apps")
+        .join(src_app_id.to_string());
     let src_media_dir_str = src_media_dir.as_ref().to_string();
     let mut listing = src_store.list(Some(&src_media_dir));
 
@@ -1434,7 +1439,7 @@ pub async fn detect_meta_in_content_store(
         .await
         .map_err(ApiError::internal_error)?
         .as_generic();
-    let prefix = flow_like_storage::Path::from("apps").child(src_app_id.to_string());
+    let prefix = flow_like_storage::Path::from("apps").join(src_app_id.to_string());
 
     const META_SUFFIXES: &[&str] = &[".board", ".event", ".template", ".widget", ".page"];
     let mut leaks: Vec<String> = Vec::new();
@@ -1598,8 +1603,8 @@ impl ForkContext {
             remote_event_token: spec.remote_event_token(state),
             dst_visibility: spec.visibility.clone(),
             now: chrono::Utc::now().fixed_offset(),
-            src_prefix: Path::from("apps").child(src_app_id.clone()),
-            dst_prefix: Path::from("apps").child(fork_job.dest_app_id.clone()),
+            src_prefix: Path::from("apps").join(src_app_id.clone()),
+            dst_prefix: Path::from("apps").join(fork_job.dest_app_id.clone()),
             policy: spec.policy.clone(),
             src_meta_rows: meta::Entity::find()
                 .filter(meta::Column::AppId.eq(src_app_id.as_str()))
@@ -1640,14 +1645,14 @@ impl ForkContext {
 
     pub(crate) fn src_media_prefix(&self) -> Path {
         Path::from("media")
-            .child("apps")
-            .child(self.src_app_id.clone())
+            .join("apps")
+            .join(self.src_app_id.clone())
     }
 
     pub(crate) fn dst_media_prefix(&self) -> Path {
         Path::from("media")
-            .child("apps")
-            .child(self.dest_app_id.clone())
+            .join("apps")
+            .join(self.dest_app_id.clone())
     }
 }
 
@@ -1715,7 +1720,7 @@ pub(crate) async fn materialize_meta(
     // `visibility`, `version`, `execution_mode`, `allow_forking`, etc.
     // can be arbitrarily stale. Overlay the DB row's authoritative
     // values before remap so the fork ships current state.
-    let manifest_path = src_prefix.child("manifest.app");
+    let manifest_path = src_prefix.clone().join("manifest.app");
     let mut src_app_proto: proto::App =
         from_compressed(src_meta_store.clone(), manifest_path.clone())
             .await
@@ -1806,7 +1811,7 @@ pub(crate) async fn materialize_meta(
         );
     }
     for src_board_id in src_app_proto.boards.iter().filter(|_| policy.flows) {
-        let board_path = src_prefix.child(format!("{}.board", src_board_id));
+        let board_path = src_prefix.clone().join(format!("{}.board", src_board_id));
         let mut board_proto: proto::Board = match from_compressed::<proto::Board>(
             src_meta_store.clone(),
             board_path,
@@ -1858,7 +1863,7 @@ pub(crate) async fn materialize_meta(
         .collect();
     for (_src_board_id, new_board_id, mut board) in new_board_protos {
         retain_shipped_board_pages(&mut board, &shipped_page_dst_ids);
-        let board_path = dst_prefix.child(format!("{}.board", new_board_id));
+        let board_path = dst_prefix.clone().join(format!("{}.board", new_board_id));
         compress_to_file(dst_meta_store.clone(), board_path, &board)
             .await
             .map_err(|e| ApiError::internal_error(anyhow!("write board: {e}")))?;
@@ -1880,7 +1885,7 @@ pub(crate) async fn materialize_meta(
     // versioned board files in step 4d below — versions not pointed to
     // are intentionally NOT copied (forks are seeded from the live
     // board, not from the version archive).
-    let dst_events_dir = dst_prefix.child("events");
+    let dst_events_dir = dst_prefix.clone().join("events");
     let mut pointed_board_versions: std::collections::HashSet<(String, (u32, u32, u32))> =
         std::collections::HashSet::new();
     let mut rewritten_events: HashMap<String, flow_like::flow::event::Event> = HashMap::new();
@@ -1997,7 +2002,9 @@ pub(crate) async fn materialize_meta(
 
         remap_event(&mut event_proto, &maps);
         let new_event_id = event_proto.id.clone();
-        let dst_event_path = dst_events_dir.child(format!("{}.event", new_event_id));
+        let dst_event_path = dst_events_dir
+            .clone()
+            .join(format!("{}.event", new_event_id));
         compress_to_file(dst_meta_store.clone(), dst_event_path, &event_proto)
             .await
             .map_err(|e| ApiError::internal_error(anyhow!("write event: {e}")))?;
@@ -2024,9 +2031,10 @@ pub(crate) async fn materialize_meta(
         }
         let dst_board_id = maps.translate_board(src_board_id);
         let src_path = src_prefix
-            .child("versions")
-            .child(src_board_id.clone())
-            .child(format!("{}_{}_{}.board", version.0, version.1, version.2));
+            .clone()
+            .join("versions")
+            .join(src_board_id.clone())
+            .join(format!("{}_{}_{}.board", version.0, version.1, version.2));
         let board_proto: proto::Board = match from_compressed::<proto::Board>(
             src_meta_store.clone(),
             src_path,
@@ -2059,9 +2067,10 @@ pub(crate) async fn materialize_meta(
         // destination live-board id so the archive stays addressable.
         remapped.id = dst_board_id.clone();
         let dst_path = dst_prefix
-            .child("versions")
-            .child(dst_board_id)
-            .child(format!("{}_{}_{}.board", version.0, version.1, version.2));
+            .clone()
+            .join("versions")
+            .join(dst_board_id)
+            .join(format!("{}_{}_{}.board", version.0, version.1, version.2));
         compress_to_file(dst_meta_store.clone(), dst_path, &remapped)
             .await
             .map_err(|e| ApiError::internal_error(anyhow!("write versioned board: {e}")))?;
@@ -2139,8 +2148,8 @@ pub(crate) async fn materialize_meta(
     copy_metadata_with_translation(
         &src_content_store,
         &dst_content_store,
-        &src_prefix.child("metadata"),
-        &dst_prefix.child("metadata"),
+        &src_prefix.clone().join("metadata"),
+        &dst_prefix.clone().join("metadata"),
         &maps,
         &shipped_widgets,
         &shipped_templates,
@@ -2269,7 +2278,7 @@ pub(crate) async fn materialize_meta(
 
     compress_to_file(
         dst_meta_store.clone(),
-        dst_prefix.child("manifest.app"),
+        dst_prefix.clone().join("manifest.app"),
         &src_app_proto,
     )
     .await
@@ -2651,8 +2660,8 @@ pub async fn materialize_uploaded_app_media(
 ) -> Result<(), ApiError> {
     let credentials = state.master_credentials().await?;
     let content_store = credentials.to_store(false).await?.as_generic();
-    let src_media_dir = Path::from("apps").child(app_id.to_string()).child("media");
-    let dst_media_dir = Path::from("media").child("apps").child(app_id.to_string());
+    let src_media_dir = Path::from("apps").join(app_id.to_string()).join("media");
+    let dst_media_dir = Path::from("media").join("apps").join(app_id.to_string());
 
     // NOT a fork: this is offline → online upload finalization, and the
     // source is deleted immediately below. A skip predicate here would
@@ -2685,9 +2694,7 @@ pub async fn sync_uploaded_metadata_media_to_db(
 ) -> Result<(), ApiError> {
     let credentials = state.master_credentials().await?;
     let content_store = credentials.to_store(false).await?.as_generic();
-    let metadata_dir = Path::from("apps")
-        .child(app_id.to_string())
-        .child("metadata");
+    let metadata_dir = Path::from("apps").join(app_id.to_string()).join("metadata");
     let metadata_dir_str = metadata_dir.as_ref().to_string();
 
     let mut listing = content_store.list(Some(&metadata_dir));
@@ -3114,9 +3121,9 @@ async fn copy_one(
 /// Append a `/`-separated *relative* path below `prefix`, one segment at
 /// a time.
 ///
-/// `Path::child` treats its argument as a single `PathPart` and
-/// percent-encodes the delimiter, so `prefix.child("db/x.lance/data/y")`
-/// yields `prefix/db%2Fx.lance%2Fdata%2Fy` — one flat key instead of a
+/// `Path::join` treats its argument as a single `PathPart` and
+/// percent-encodes the delimiter, so `prefix.join("db/x.lance/data/y")`
+/// yields `prefix/db%2Fx.lance%2Fdata%2Fy`, one flat key instead of a
 /// nested path. Every content mirror below has to fold per segment or
 /// the destination silently ends up with garbage keys (this is what
 /// used to drop the entire project LanceDB under `storage/db/**` on
@@ -3125,7 +3132,7 @@ fn join_relative(prefix: &Path, relative: &str) -> Path {
     relative
         .split('/')
         .filter(|segment| !segment.is_empty())
-        .fold(prefix.clone(), |acc, segment| acc.child(segment))
+        .fold(prefix.clone(), |acc, segment| acc.join(segment))
 }
 
 /// Bytes + objects a single prefix mirror moved. Summed into
@@ -3424,7 +3431,7 @@ async fn read_source_page(
     src_board_id: Option<&str>,
     src_page_id: &str,
 ) -> Option<proto::Page> {
-    let app_level = src_prefix.child(format!("{}.page", src_page_id));
+    let app_level = src_prefix.clone().join(format!("{}.page", src_page_id));
     if let Ok(page) =
         from_compressed_json::<flow_like::a2ui::widget::Page>(src_store.clone(), app_level).await
     {
@@ -3433,8 +3440,9 @@ async fn read_source_page(
 
     if let Some(board_id) = src_board_id {
         let board_level = src_prefix
-            .child(format!("_{}", board_id))
-            .child(format!("{}.page", src_page_id));
+            .clone()
+            .join(format!("_{}", board_id))
+            .join(format!("{}.page", src_page_id));
         if let Ok(page) = from_compressed::<proto::Page>(src_store.clone(), board_level).await {
             return Some(page);
         }
@@ -3571,8 +3579,9 @@ async fn write_destination_page(
         return Ok(());
     };
     let board_level = dst_prefix
-        .child(format!("_{}", board_id))
-        .child(format!("{}.page", page_proto.id));
+        .clone()
+        .join(format!("_{}", board_id))
+        .join(format!("{}.page", page_proto.id));
     compress_to_file(dst_store.clone(), board_level, page_proto)
         .await
         .map_err(|e| ApiError::internal_error(anyhow!("write page: {e}")))?;
@@ -3771,7 +3780,7 @@ async fn fork_widgets(
 ) -> Result<HashSet<String>, ApiError> {
     let mut shipped_widgets = HashSet::new();
     for (src_widget_id, new_widget_id) in &maps.widgets {
-        let src_path = src_prefix.child(format!("{}.widget", src_widget_id));
+        let src_path = src_prefix.clone().join(format!("{}.widget", src_widget_id));
         let mut widget: flow_like_types::Value =
             match from_compressed_json(src_store.clone(), src_path).await {
                 Ok(w) => w,
@@ -3806,7 +3815,7 @@ async fn fork_widgets(
                 ),
             });
         }
-        let dst_path = dst_prefix.child(format!("{}.widget", new_widget_id));
+        let dst_path = dst_prefix.clone().join(format!("{}.widget", new_widget_id));
         compress_to_file_json(dst_store.clone(), dst_path, &widget)
             .await
             .map_err(|e| ApiError::internal_error(anyhow!("write widget: {e}")))?;
@@ -3840,7 +3849,9 @@ async fn fork_templates(
             let page_id = maps.mint(src_page_id);
             maps.pages.entry(src_page_id.clone()).or_insert(page_id);
         }
-        let src_path = src_prefix.child(format!("{}.template", src_template_id));
+        let src_path = src_prefix
+            .clone()
+            .join(format!("{}.template", src_template_id));
         let board_proto: proto::Board =
             match from_compressed::<proto::Board>(src_store.clone(), src_path).await {
                 Ok(b) => b,
@@ -3864,7 +3875,9 @@ async fn fork_templates(
         // remap_board rewrote board.id to a fresh id; force it back to
         // the chosen template id for path consistency.
         remapped.id = new_template_id.clone();
-        let dst_path = dst_prefix.child(format!("{}.template", new_template_id));
+        let dst_path = dst_prefix
+            .clone()
+            .join(format!("{}.template", new_template_id));
         compress_to_file(dst_store.clone(), dst_path, &remapped)
             .await
             .map_err(|e| ApiError::internal_error(anyhow!("write template: {e}")))?;
@@ -3880,8 +3893,9 @@ async fn fork_templates(
         .await?
         {
             let dst_page_path = dst_prefix
-                .child(format!("_template_{}", new_template_id))
-                .child(format!("{}.page", template_page.id));
+                .clone()
+                .join(format!("_template_{}", new_template_id))
+                .join(format!("{}.page", template_page.id));
             compress_to_file(dst_store.clone(), dst_page_path, &template_page)
                 .await
                 .map_err(|e| ApiError::internal_error(anyhow!("write template page: {e}")))?;
@@ -3916,7 +3930,9 @@ async fn list_template_page_ids(
     src_template_id: &str,
     skipped: &mut Vec<SkippedItem>,
 ) -> Vec<String> {
-    let template_dir = src_prefix.child(format!("_template_{}", src_template_id));
+    let template_dir = src_prefix
+        .clone()
+        .join(format!("_template_{}", src_template_id));
     let mut listing = src_store.list(Some(&template_dir));
     let mut source_page_ids: Vec<String> = Vec::new();
     loop {
@@ -3969,10 +3985,12 @@ async fn read_template_pages(
     maps: &ForkIdMap,
     skipped: &mut Vec<SkippedItem>,
 ) -> Result<Vec<proto::Page>, ApiError> {
-    let template_dir = src_prefix.child(format!("_template_{}", src_template_id));
+    let template_dir = src_prefix
+        .clone()
+        .join(format!("_template_{}", src_template_id));
     let mut pages = Vec::with_capacity(src_page_ids.len());
     for src_page_id in src_page_ids {
-        let src_path = template_dir.child(format!("{}.page", src_page_id));
+        let src_path = template_dir.clone().join(format!("{}.page", src_page_id));
         let mut page_proto = match from_compressed::<proto::Page>(src_store.clone(), src_path).await
         {
             Ok(page) => page,
@@ -4846,7 +4864,7 @@ mod tests {
 
     #[test]
     fn join_relative_keeps_nested_paths_nested() {
-        let prefix = Path::from("apps").child("dst").child("storage");
+        let prefix = Path::from("apps").join("dst").join("storage");
 
         assert_eq!(
             join_relative(&prefix, "db/tables.lance/data/chunk.lance").as_ref(),
@@ -4858,10 +4876,13 @@ mod tests {
         );
         assert_eq!(join_relative(&prefix, "").as_ref(), "apps/dst/storage");
 
-        // The bug this guards against: `child` percent-encodes the
+        // The bug this guards against: `join` percent-encodes the
         // delimiter, flattening the whole relative path into one key.
         assert_ne!(
-            prefix.child("db/tables.lance/data/chunk.lance").as_ref(),
+            prefix
+                .clone()
+                .join("db/tables.lance/data/chunk.lance")
+                .as_ref(),
             join_relative(&prefix, "db/tables.lance/data/chunk.lance").as_ref()
         );
     }

--- a/packages/api/src/utils/fork/preview.rs
+++ b/packages/api/src/utils/fork/preview.rs
@@ -47,7 +47,7 @@ impl RemoteTokenSite {
 /// `forking.max_file_count` on every fork. The byte cap stays the real
 /// resource guard.
 pub fn project_db_prefix(app_prefix: &Path) -> Path {
-    app_prefix.child("storage").child("db")
+    app_prefix.clone().join("storage").join("db")
 }
 
 fn is_under_prefix(location: &Path, prefix: &Path) -> bool {
@@ -153,7 +153,7 @@ pub async fn compute_fork_size_breakdown(
         .map_err(ApiError::internal_error)?
         .as_generic();
 
-    let prefix = Path::from("apps").child(app_id.to_string());
+    let prefix = Path::from("apps").join(app_id.to_string());
     let mut breakdown = ForkSizeBreakdown::default();
 
     bucket_prefix(&meta_store, &prefix, &mut breakdown, classify_meta).await?;
@@ -166,7 +166,7 @@ pub async fn compute_fork_size_breakdown(
     // computes the true total.
     bucket_prefix(&content_store, &prefix, &mut breakdown, classify_content).await?;
 
-    let media_prefix = Path::from("media").child("apps").child(app_id.to_string());
+    let media_prefix = Path::from("media").join("apps").join(app_id.to_string());
     bucket_prefix(&content_store, &media_prefix, &mut breakdown, |_| {
         (ForkCategory::Always, true)
     })
@@ -313,8 +313,8 @@ pub async fn compute_app_content_size_and_count(
         .map_err(ApiError::internal_error)?
         .as_generic();
 
-    let app_prefix = Path::from("apps").child(app_id.to_string());
-    let media_prefix = Path::from("media").child("apps").child(app_id.to_string());
+    let app_prefix = Path::from("apps").join(app_id.to_string());
+    let media_prefix = Path::from("media").join("apps").join(app_id.to_string());
     let db_prefix = project_db_prefix(&app_prefix);
 
     let (app_bytes, app_count) = sum_prefix(&content_store, &app_prefix, Some(&db_prefix)).await?;

--- a/packages/catalog/benches/allocator_bench.rs
+++ b/packages/catalog/benches/allocator_bench.rs
@@ -91,7 +91,7 @@ fn construct_profile() -> Profile {
 }
 
 async fn open_board(id: &str, state: Arc<FlowLikeState>) -> Board {
-    let path = Path::from("flow").child(&*app_id());
+    let path = Path::from("flow").join(&*app_id());
     let mut board = Board::load(path, id, state, None)
         .await
         .expect("load board");

--- a/packages/catalog/benches/flow_bench.rs
+++ b/packages/catalog/benches/flow_bench.rs
@@ -59,7 +59,7 @@ async fn default_state() -> Arc<FlowLikeState> {
 }
 
 async fn open_board(id: &str, state: Arc<FlowLikeState>) -> Board {
-    let path = Path::from("flow").child(APP_ID);
+    let path = Path::from("flow").join(APP_ID);
     Board::load(path, id, state, None).await.unwrap()
 }
 

--- a/packages/catalog/benches/throughput_bench.rs
+++ b/packages/catalog/benches/throughput_bench.rs
@@ -130,7 +130,7 @@ fn construct_profile() -> Profile {
 }
 
 async fn open_board(id: &str, state: Arc<FlowLikeState>) -> Board {
-    let path = Path::from("flow").child(&*app_id());
+    let path = Path::from("flow").join(&*app_id());
     let mut board = Board::load(path, id, state, None)
         .await
         .expect("load board");

--- a/packages/catalog/data/src/data/db/graph.rs
+++ b/packages/catalog/data/src/data/db/graph.rs
@@ -181,7 +181,7 @@ impl NodeLogic for OpenGraphOverlayNode {
                 }
             } else if user_scoped {
                 let user_dir = context_cache.get_user_dir(false)?;
-                let user_dir = user_dir.child("db");
+                let user_dir = user_dir.join("db");
                 context
                     .app_state
                     .config
@@ -195,7 +195,7 @@ impl NodeLogic for OpenGraphOverlayNode {
                 )
             } else {
                 let board_dir = context_cache.get_storage(false)?;
-                let board_dir = board_dir.child("db");
+                let board_dir = board_dir.join("db");
                 context
                     .app_state
                     .config
@@ -354,7 +354,7 @@ impl NodeLogic for CreateGraphOverlayNode {
             }
         } else if user_scoped {
             let user_dir = context_cache.get_user_dir(false)?;
-            let user_dir = user_dir.child("db");
+            let user_dir = user_dir.join("db");
             context
                 .app_state
                 .config
@@ -368,7 +368,7 @@ impl NodeLogic for CreateGraphOverlayNode {
             )
         } else {
             let board_dir = context_cache.get_storage(false)?;
-            let board_dir = board_dir.child("db");
+            let board_dir = board_dir.join("db");
             context
                 .app_state
                 .config

--- a/packages/catalog/data/src/data/db/graph/drop_overlay.rs
+++ b/packages/catalog/data/src/data/db/graph/drop_overlay.rs
@@ -94,7 +94,7 @@ impl NodeLogic for DropGraphOverlayNode {
             }
         } else if user_scoped {
             let user_dir = context_cache.get_user_dir(false)?;
-            let user_dir = user_dir.child("db");
+            let user_dir = user_dir.join("db");
             context
                 .app_state
                 .config
@@ -108,7 +108,7 @@ impl NodeLogic for DropGraphOverlayNode {
             )
         } else {
             let board_dir = context_cache.get_storage(false)?;
-            let board_dir = board_dir.child("db");
+            let board_dir = board_dir.join("db");
             context
                 .app_state
                 .config

--- a/packages/catalog/data/src/data/db/graph/list_overlays.rs
+++ b/packages/catalog/data/src/data/db/graph/list_overlays.rs
@@ -87,7 +87,7 @@ impl NodeLogic for ListGraphOverlaysNode {
             }
         } else if user_scoped {
             let user_dir = context_cache.get_user_dir(false)?;
-            let user_dir = user_dir.child("db");
+            let user_dir = user_dir.join("db");
             context
                 .app_state
                 .config
@@ -101,7 +101,7 @@ impl NodeLogic for ListGraphOverlaysNode {
             )
         } else {
             let board_dir = context_cache.get_storage(false)?;
-            let board_dir = board_dir.child("db");
+            let board_dir = board_dir.join("db");
             context
                 .app_state
                 .config

--- a/packages/catalog/data/src/data/db/graph/ontology_action.rs
+++ b/packages/catalog/data/src/data/db/graph/ontology_action.rs
@@ -146,7 +146,7 @@ impl NodeLogic for OntologyActionRequestNode {
         let database = if let Some(credentials) = &context.credentials {
             credentials.to_db(&app_id).await?
         } else {
-            let path = execution.get_storage(false)?.child("db");
+            let path = execution.get_storage(false)?.join("db");
             context
                 .app_state
                 .config

--- a/packages/catalog/data/src/data/db/graph/ontology_action_remote.rs
+++ b/packages/catalog/data/src/data/db/graph/ontology_action_remote.rs
@@ -169,7 +169,7 @@ impl NodeLogic for RemoteOntologyActionRequestNode {
         let database = if let Some(credentials) = &context.credentials {
             credentials.to_db(&app_id).await?
         } else {
-            let path = execution.get_storage(false)?.child("db");
+            let path = execution.get_storage(false)?.join("db");
             context
                 .app_state
                 .config

--- a/packages/catalog/data/src/data/db/graph/ontology_query.rs
+++ b/packages/catalog/data/src/data/db/graph/ontology_query.rs
@@ -102,7 +102,7 @@ impl NodeLogic for QueryOntologyObjectsNode {
         let database = if let Some(credentials) = &context.credentials {
             credentials.to_db(&app_id).await?
         } else {
-            let path = execution.get_storage(false)?.child("db");
+            let path = execution.get_storage(false)?.join("db");
             context
                 .app_state
                 .config

--- a/packages/catalog/data/src/data/db/graph/ontology_remote_children.rs
+++ b/packages/catalog/data/src/data/db/graph/ontology_remote_children.rs
@@ -123,7 +123,7 @@ impl NodeLogic for QueryRemoteOntologyChildrenNode {
         let database = if let Some(credentials) = &context.credentials {
             credentials.to_db(&app_id).await?
         } else {
-            let path = execution.get_storage(false)?.child("db");
+            let path = execution.get_storage(false)?.join("db");
             context
                 .app_state
                 .config

--- a/packages/catalog/data/src/data/db/graph/ontology_remote_query.rs
+++ b/packages/catalog/data/src/data/db/graph/ontology_remote_query.rs
@@ -114,7 +114,7 @@ impl NodeLogic for QueryRemoteOntologyObjectsNode {
         let database = if let Some(credentials) = &context.credentials {
             credentials.to_db(&app_id).await?
         } else {
-            let path = execution.get_storage(false)?.child("db");
+            let path = execution.get_storage(false)?.join("db");
             context
                 .app_state
                 .config

--- a/packages/catalog/data/src/data/db/vector.rs
+++ b/packages/catalog/data/src/data/db/vector.rs
@@ -137,7 +137,7 @@ impl NodeLogic for CreateLocalDatabaseNode {
                 }
             } else if user_scoped {
                 let user_dir = context_cache.get_user_dir(false)?;
-                let user_dir = user_dir.child("db");
+                let user_dir = user_dir.join("db");
                 context
                     .app_state
                     .config
@@ -151,7 +151,7 @@ impl NodeLogic for CreateLocalDatabaseNode {
                 )
             } else {
                 let board_dir = context_cache.get_storage(false)?;
-                let board_dir = board_dir.child("db");
+                let board_dir = board_dir.join("db");
                 context
                     .app_state
                     .config

--- a/packages/catalog/data/src/data/db/vector/list_tables.rs
+++ b/packages/catalog/data/src/data/db/vector/list_tables.rs
@@ -78,7 +78,7 @@ impl NodeLogic for ListTablesNode {
             }
         } else if user_scoped {
             let user_dir = context_cache.get_user_dir(false)?;
-            let user_dir = user_dir.child("db");
+            let user_dir = user_dir.join("db");
             context
                 .app_state
                 .config
@@ -92,7 +92,7 @@ impl NodeLogic for ListTablesNode {
             )
         } else {
             let board_dir = context_cache.get_storage(false)?;
-            let board_dir = board_dir.child("db");
+            let board_dir = board_dir.join("db");
             context
                 .app_state
                 .config

--- a/packages/catalog/data/src/data/path/manipulation/child.rs
+++ b/packages/catalog/data/src/data/path/manipulation/child.rs
@@ -62,7 +62,7 @@ impl NodeLogic for ChildNode {
 
         let mut path = parent_path.to_runtime(context).await?;
         for child_segment in child_segments {
-            path.path = path.path.child(child_segment);
+            path.path = path.path.join(child_segment);
         }
         let path = path.serialize().await;
 

--- a/packages/catalog/data/src/data/path/manipulation/parent.rs
+++ b/packages/catalog/data/src/data/path/manipulation/parent.rs
@@ -68,9 +68,9 @@ impl NodeLogic for ParentNode {
         let mut parts = path.path.parts().collect::<Vec<_>>();
         parts.pop();
         let mut new_path = Path::from("");
-        parts.iter().for_each(|part| {
-            new_path = new_path.child(part.as_ref());
-        });
+        for part in &parts {
+            new_path = new_path.join(part.as_ref());
+        }
         path.path = new_path;
         let path = path.serialize().await;
 

--- a/packages/catalog/data/support/src/cache.rs
+++ b/packages/catalog/data/support/src/cache.rs
@@ -180,14 +180,14 @@ fn resolve_transport(context: &ExecutionContext) -> flow_like_types::Result<Cach
     Ok(CacheTransport::Local {
         store,
         root: Path::from("apps")
-            .child(execution_cache.app_id.clone())
-            .child(LOCAL_CACHE_DIR),
+            .join(execution_cache.app_id.clone())
+            .join(LOCAL_CACHE_DIR),
     })
 }
 
 fn local_scope_dir(root: &Path, scope: CacheScope, sub: &str) -> flow_like_types::Result<Path> {
     match scope {
-        CacheScope::App => Ok(root.child(LOCAL_APP_SCOPE_DIR)),
+        CacheScope::App => Ok(root.clone().join(LOCAL_APP_SCOPE_DIR)),
         CacheScope::User => {
             let sub = sub.trim();
             if sub.is_empty() {
@@ -195,7 +195,10 @@ fn local_scope_dir(root: &Path, scope: CacheScope, sub: &str) -> flow_like_types
                     "User-scoped cache requires an identifiable user"
                 ));
             }
-            Ok(root.child(LOCAL_USER_SCOPE_DIR).child(sub.to_string()))
+            Ok(root
+                .clone()
+                .join(LOCAL_USER_SCOPE_DIR)
+                .join(sub.to_string()))
         }
     }
 }
@@ -216,7 +219,7 @@ fn local_entry_path(
     hasher.update(namespace.as_bytes());
     hasher.update(key.as_bytes());
     let file = hasher.finalize().to_hex().to_string();
-    Ok(scoped.child(format!("{file}.json")))
+    Ok(scoped.join(format!("{file}.json")))
 }
 
 /// Read an entry. Returns `None` for both "absent" and "expired".
@@ -729,7 +732,7 @@ mod tests {
 
     #[test]
     fn local_paths_separate_scopes_users_and_namespaces() {
-        let root = Path::from("apps").child("app-1").child(LOCAL_CACHE_DIR);
+        let root = Path::from("apps").join("app-1").join(LOCAL_CACHE_DIR);
 
         let app = local_entry_path(&root, CacheScope::App, "", "", "k").unwrap();
         let alice = local_entry_path(&root, CacheScope::User, "alice", "", "k").unwrap();
@@ -755,7 +758,7 @@ mod tests {
 
     #[test]
     fn keys_with_path_separators_stay_inside_the_scope_directory() {
-        let root = Path::from("apps").child("app-1").child(LOCAL_CACHE_DIR);
+        let root = Path::from("apps").join("app-1").join(LOCAL_CACHE_DIR);
         let traversal =
             local_entry_path(&root, CacheScope::App, "", "../ns", "../../escape").unwrap();
         assert!(traversal.as_ref().starts_with("apps/app-1/cache/global/"));

--- a/packages/catalog/examples/board_compiled_bench.rs
+++ b/packages/catalog/examples/board_compiled_bench.rs
@@ -101,7 +101,7 @@ async fn default_state(root: PathBuf) -> Arc<FlowLikeState> {
 async fn main() {
     let root = PathBuf::from(std::env::args().nth(1).expect("pass store root dir"));
     let state = default_state(root).await;
-    let path = Path::from("flow").child(APP_ID);
+    let path = Path::from("flow").join(APP_ID);
 
     let t = Instant::now();
     let board = Board::load(path.clone(), BOARD_ID, state.clone(), None)

--- a/packages/catalog/examples/board_parse_baseline.rs
+++ b/packages/catalog/examples/board_parse_baseline.rs
@@ -109,7 +109,7 @@ async fn main() {
         t.elapsed()
     );
 
-    let path = Path::from("flow").child(APP_ID);
+    let path = Path::from("flow").join(APP_ID);
 
     let t = Instant::now();
     let board = Board::load(path.clone(), BOARD_ID, state.clone(), None)

--- a/packages/catalog/llm/src/agent/lazy_register_tools.rs
+++ b/packages/catalog/llm/src/agent/lazy_register_tools.rs
@@ -154,7 +154,7 @@ impl NodeLogic for LazyRegisterFunctionToolsNode {
                 credentials.to_db(&context_cache.app_id).await?
             } else {
                 let board_dir = context_cache.get_storage(false)?;
-                let agents_dir = board_dir.child(".agents");
+                let agents_dir = board_dir.join(".agents");
                 context
                     .app_state
                     .config

--- a/packages/catalog/media-video/Cargo.toml
+++ b/packages/catalog/media-video/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 async-trait.workspace = true
 http = "1.4.0"
 zip = { version = "8.2.0", default-features = false, features = ["deflate-flate2-zlib-rs"], optional = true }
-video-utils-rs = { git = "https://github.com/Rheosoph/video-utils-rs.git", rev = "4b4e380fd719390dd8598120ebfb50566d234d5c", default-features = false, features = ["portable-core", "platform-codecs", "audio-io", "image-io", "preview", "codec-h264-rust", "codec-h265-rust", "codec-av1-rust", "codec-openh264-ffi", "codec-apple", "codec-android", "codec-windows", "codec-gstreamer", "codec-web"], optional = true }
+video-utils-rs = { git = "https://github.com/Rheosoph/video-utils-rs.git", rev = "b4c9185504f98b1eb8eb9d34c8baa0b6f5f8cab4", default-features = false, features = ["portable-core", "platform-codecs", "audio-io", "image-io", "preview", "codec-h264-rust", "codec-h265-rust", "codec-av1-rust", "codec-openh264-ffi", "codec-apple", "codec-android", "codec-windows", "codec-gstreamer", "codec-web"], optional = true }
 flow-like-catalog-media-support.workspace = true
 
 [build-dependencies]

--- a/packages/catalog/onnx/src/face_id.rs
+++ b/packages/catalog/onnx/src/face_id.rs
@@ -1105,7 +1105,7 @@ async fn upload_model_file(
             if !matches!(
                 &multipart_error,
                 flow_like_storage::object_store::Error::NotSupported { .. }
-                    | flow_like_storage::object_store::Error::NotImplemented
+                    | flow_like_storage::object_store::Error::NotImplemented { .. }
             ) {
                 return Err(anyhow!(
                     "Failed to start multipart model cache upload: {multipart_error}"

--- a/packages/catalog/std-ui/src/a2ui/elements/get_file_input_files.rs
+++ b/packages/catalog/std-ui/src/a2ui/elements/get_file_input_files.rs
@@ -460,7 +460,7 @@ async fn materialize_missing_flow_paths(
                         file_name
                     )
                 })?;
-                let object_path = Path::from("files").child(file_name.as_str());
+                let object_path = Path::from("files").join(file_name.as_str());
                 FlowPath::new(object_path.as_ref().to_string(), store_ref.clone(), None)
             }
         };

--- a/packages/catalog/web/src/web/rest.rs
+++ b/packages/catalog/web/src/web/rest.rs
@@ -2283,7 +2283,7 @@ async fn file_route_response(
         } => {
             let filename = rest_file_route_filename(path, &request_path)?;
             let decoded_filename = decode_rest_file_name(&filename);
-            let object_path = prefix.path.child(decoded_filename.as_str());
+            let object_path = prefix.path.clone().join(decoded_filename.as_str());
             let file = match prefix.store.as_generic().get(&object_path).await {
                 Ok(file) => file,
                 Err(_) => {
@@ -2936,14 +2936,14 @@ mod tests {
         let memory = Arc::new(InMemory::new());
         memory
             .put(
-                &Path::from("assets").child("hello.txt"),
+                &Path::from("assets").join("hello.txt"),
                 PutPayload::from("hello"),
             )
             .await
             .unwrap();
         memory
             .put(
-                &Path::from("assets").child("nested/name.txt"),
+                &Path::from("assets").join("nested/name.txt"),
                 PutPayload::from("encoded slash"),
             )
             .await

--- a/packages/core/editor/src/flow/copilot/memory.rs
+++ b/packages/core/editor/src/flow/copilot/memory.rs
@@ -93,10 +93,10 @@ impl AssistantMemory {
     ) -> Result<LanceDBVectorStore> {
         let dir = match owner.map(str::trim).filter(|owner| !owner.is_empty()) {
             Some(owner) => Path::from("users")
-                .child(owner)
-                .child("assistant-memory")
-                .child(profile_id),
-            None => Path::from("assistant-memory").child(profile_id),
+                .join(owner)
+                .join("assistant-memory")
+                .join(profile_id),
+            None => Path::from("assistant-memory").join(profile_id),
         };
         let builder = {
             let config = state.config.read().await;

--- a/packages/core/runtime/src/app.rs
+++ b/packages/core/runtime/src/app.rs
@@ -290,14 +290,14 @@ impl App {
     }
 
     pub async fn load(id: String, app_state: Arc<FlowLikeState>) -> flow_like_types::Result<Self> {
-        let storage_root = Path::from("apps").child(id.clone());
+        let storage_root = Path::from("apps").join(id.clone());
 
         let store = FlowLikeState::project_meta_store(&app_state)
             .await?
             .as_generic();
 
         let app: flow_like_types::proto::App =
-            from_compressed(store, storage_root.child("manifest.app")).await?;
+            from_compressed(store, storage_root.join("manifest.app")).await?;
         let mut app = App::from_proto(app);
         app.app_state = Some(app_state.clone());
 
@@ -327,9 +327,9 @@ impl App {
             .await?
             .as_generic();
 
-        let mut metadata_path = Path::from("apps").child(id).child("metadata");
+        let mut metadata_path = Path::from("apps").join(id).join("metadata");
         if let Some(template_id) = template_id {
-            metadata_path = metadata_path.child("templates").child(template_id);
+            metadata_path = metadata_path.join("templates").join(template_id);
         }
         let languages = [
             language.unwrap_or_else(|| "en".to_string()),
@@ -341,7 +341,7 @@ impl App {
             .iter()
             .take_while(|&l| l != &languages[1] || l == &languages[0])
         {
-            let meta_path = metadata_path.child(format!("{}.meta", lang));
+            let meta_path = metadata_path.clone().join(format!("{}.meta", lang));
 
             if let Ok(metadata) = from_compressed::<proto::Metadata>(store.clone(), meta_path).await
             {
@@ -367,13 +367,13 @@ impl App {
             .as_generic();
 
         let language = language.unwrap_or_else(|| "en".to_string());
-        let mut meta_path = Path::from("apps").child(id).child("metadata");
+        let mut meta_path = Path::from("apps").join(id).join("metadata");
 
         if let Some(template_id) = template_id {
-            meta_path = meta_path.child("templates").child(template_id);
+            meta_path = meta_path.join("templates").join(template_id);
         }
 
-        let meta_path = meta_path.child(format!("{}.meta", language));
+        let meta_path = meta_path.join(format!("{}.meta", language));
 
         let proto_metadata = metadata.to_proto();
         compress_to_file(store, meta_path, &proto_metadata).await?;
@@ -386,7 +386,7 @@ impl App {
         id: Option<String>,
         template: Option<Board>,
     ) -> flow_like_types::Result<CreatedBoard> {
-        let storage_root = Path::from("apps").child(self.id.clone());
+        let storage_root = Path::from("apps").join(self.id.clone());
         let state = self
             .app_state
             .clone()
@@ -493,7 +493,7 @@ impl App {
         register: Option<bool>,
         version: Option<(u32, u32, u32)>,
     ) -> flow_like_types::Result<Arc<Mutex<Board>>> {
-        let storage_root = Path::from("apps").child(self.id.clone());
+        let storage_root = Path::from("apps").join(self.id.clone());
         if let Some(app_state) = &self.app_state {
             let board = app_state.get_board(&board_id, version);
 
@@ -531,7 +531,7 @@ impl App {
         board_id: String,
         version: Option<(u32, u32, u32)>,
     ) -> flow_like_types::Result<Arc<Mutex<Board>>> {
-        let storage_root = Path::from("apps").child(self.id.clone());
+        let storage_root = Path::from("apps").join(self.id.clone());
         let state = self
             .app_state
             .clone()
@@ -543,8 +543,8 @@ impl App {
     pub async fn delete_board(&mut self, board_id: &str) -> flow_like_types::Result<()> {
         self.boards.retain(|b| b != board_id);
         let board_dir = Path::from("apps")
-            .child(self.id.clone())
-            .child(format!("{}.board", board_id));
+            .join(self.id.clone())
+            .join(format!("{}.board", board_id));
 
         let state = self
             .app_state
@@ -561,9 +561,9 @@ impl App {
 
         // Remove all versions of the board
         let versions_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("versions")
-            .child(board_id);
+            .join(self.id.clone())
+            .join("versions")
+            .join(board_id);
         let locations = store
             .list(Some(&versions_path))
             .map_ok(|m| m.location)
@@ -576,9 +576,9 @@ impl App {
 
         // Compiled artifacts are derived from the versions removed above.
         let compiled_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("compiled")
-            .child(board_id);
+            .join(self.id.clone())
+            .join("compiled")
+            .join(board_id);
         let compiled_locations = store
             .list(Some(&compiled_path))
             .map_ok(|m| m.location)
@@ -704,7 +704,7 @@ impl App {
         let mut data = data;
         data.app_state = Some(app_state.clone());
         data.id = template_id.clone();
-        data.board_dir = Path::from("apps").child(self.id.clone());
+        data.board_dir = Path::from("apps").join(self.id.clone());
 
         // Record-only: this is a template fetched from the hub being cached locally, so its page
         // ids have no payloads on this store to copy from.
@@ -722,7 +722,7 @@ impl App {
         template_id: &str,
         version: Option<(u32, u32, u32)>,
     ) -> flow_like_types::Result<Board> {
-        let storage_root = Path::from("apps").child(self.id.clone());
+        let storage_root = Path::from("apps").join(self.id.clone());
 
         let state = self
             .app_state
@@ -738,7 +738,7 @@ impl App {
         &self,
         template_id: &str,
     ) -> flow_like_types::Result<Vec<(u32, u32, u32)>> {
-        let storage_root = Path::from("apps").child(self.id.clone());
+        let storage_root = Path::from("apps").join(self.id.clone());
 
         let state = self
             .app_state
@@ -755,7 +755,7 @@ impl App {
         template_id: String,
         version: Option<(u32, u32, u32)>,
     ) -> flow_like_types::Result<Board> {
-        let storage_root = Path::from("apps").child(self.id.clone());
+        let storage_root = Path::from("apps").join(self.id.clone());
 
         let state = self
             .app_state
@@ -778,8 +778,8 @@ impl App {
 
     pub async fn delete_template(&mut self, template_id: &str) -> flow_like_types::Result<()> {
         let template_dir = Path::from("apps")
-            .child(self.id.clone())
-            .child(format!("{}.template", template_id));
+            .join(self.id.clone())
+            .join(format!("{}.template", template_id));
 
         let state = self
             .app_state
@@ -792,10 +792,10 @@ impl App {
 
         // Remove all versions of the board
         let versions_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("templates")
-            .child("versions")
-            .child(template_id);
+            .join(self.id.clone())
+            .join("templates")
+            .join("versions")
+            .join(template_id);
         let locations = store
             .list(Some(&versions_path))
             .map_ok(|m| m.location)
@@ -809,7 +809,7 @@ impl App {
         // The template's own page payloads sit next to the board files, outside the version tree
         // the sweep above walks, so they would otherwise outlive the template forever.
         let pages_path =
-            Board::template_pages_dir(&Path::from("apps").child(self.id.clone()), template_id);
+            Board::template_pages_dir(&Path::from("apps").join(self.id.clone()), template_id);
         let page_locations = store.list(Some(&pages_path)).map_ok(|m| m.location).boxed();
         // A template that never had pages has no directory at all, which a
         // filesystem store reports as an error rather than an empty listing.
@@ -838,11 +838,11 @@ impl App {
             .as_generic();
 
         let meta_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("metadata")
-            .child("templates")
-            .child(template_id)
-            .child(format!("{}.meta", language));
+            .join(self.id.clone())
+            .join("metadata")
+            .join("templates")
+            .join(template_id)
+            .join(format!("{}.meta", language));
 
         let proto_metadata = meta.to_proto();
         compress_to_file(store, meta_path, &proto_metadata).await?;
@@ -860,21 +860,21 @@ impl App {
 
         let language = language.unwrap_or_else(|| "en".to_string());
         let meta_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("metadata")
-            .child("templates")
-            .child(template_id)
-            .child(format!("{}.meta", language));
+            .join(self.id.clone())
+            .join("metadata")
+            .join("templates")
+            .join(template_id)
+            .join(format!("{}.meta", language));
 
         let metadata = from_compressed::<proto::Metadata>(store.clone(), meta_path).await;
         if let Err(e) = metadata {
             eprintln!("Failed to get template metadata: {}", e);
             let meta_path = Path::from("apps")
-                .child(self.id.clone())
-                .child("metadata")
-                .child("templates")
-                .child(template_id)
-                .child("en.meta");
+                .join(self.id.clone())
+                .join("metadata")
+                .join("templates")
+                .join(template_id)
+                .join("en.meta");
             let metadata = from_compressed::<proto::Metadata>(store, meta_path).await;
             if let Err(e) = metadata {
                 eprintln!("Failed to get template metadata in English: {}", e);
@@ -918,15 +918,15 @@ impl App {
 
         let widget_path = if let Some(v) = version {
             Path::from("apps")
-                .child(self.id.clone())
-                .child("widgets")
-                .child("versions")
-                .child(widget_id.as_str())
-                .child(format!("{}-{}-{}.widget", v.0, v.1, v.2))
+                .join(self.id.clone())
+                .join("widgets")
+                .join("versions")
+                .join(widget_id.as_str())
+                .join(format!("{}-{}-{}.widget", v.0, v.1, v.2))
         } else {
             Path::from("apps")
-                .child(self.id.clone())
-                .child(format!("{}.widget", widget_id))
+                .join(self.id.clone())
+                .join(format!("{}.widget", widget_id))
         };
 
         let widget: crate::a2ui::widget::Widget = from_compressed_json(store, widget_path).await?;
@@ -947,8 +947,8 @@ impl App {
             .as_generic();
 
         let widget_path = Path::from("apps")
-            .child(self.id.clone())
-            .child(format!("{}.widget", widget.id));
+            .join(self.id.clone())
+            .join(format!("{}.widget", widget.id));
 
         compress_to_file_json(store, widget_path, widget).await?;
 
@@ -986,11 +986,11 @@ impl App {
         };
 
         let meta_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("metadata")
-            .child("widgets")
-            .child(widget_id)
-            .child("en.meta");
+            .join(self.id.clone())
+            .join("metadata")
+            .join("widgets")
+            .join(widget_id)
+            .join("en.meta");
 
         store.as_generic().head(&meta_path).await.is_ok()
     }
@@ -1006,16 +1006,16 @@ impl App {
             .as_generic();
 
         let widget_path = Path::from("apps")
-            .child(self.id.clone())
-            .child(format!("{}.widget", widget_id));
+            .join(self.id.clone())
+            .join(format!("{}.widget", widget_id));
         store.delete(&widget_path).await?;
 
         // Delete all versions
         let versions_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("widgets")
-            .child("versions")
-            .child(widget_id);
+            .join(self.id.clone())
+            .join("widgets")
+            .join("versions")
+            .join(widget_id);
         let locations = store
             .list(Some(&versions_path))
             .map_ok(|m| m.location)
@@ -1032,10 +1032,10 @@ impl App {
             .await?
             .as_generic();
         let meta_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("metadata")
-            .child("widgets")
-            .child(widget_id);
+            .join(self.id.clone())
+            .join("metadata")
+            .join("widgets")
+            .join(widget_id);
         let meta_locations = meta_store
             .list(Some(&meta_path))
             .map_ok(|m| m.location)
@@ -1086,11 +1086,11 @@ impl App {
         ))?;
 
         let version_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("widgets")
-            .child("versions")
-            .child(widget_id.to_string())
-            .child(format!("{}-{}-{}.widget", version.0, version.1, version.2));
+            .join(self.id.clone())
+            .join("widgets")
+            .join("versions")
+            .join(widget_id.to_string())
+            .join(format!("{}-{}-{}.widget", version.0, version.1, version.2));
         compress_to_file_json(store, version_path, &widget).await?;
 
         self.save_widget(&widget).await?;
@@ -1112,10 +1112,10 @@ impl App {
             .as_generic();
 
         let versions_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("widgets")
-            .child("versions")
-            .child(widget_id);
+            .join(self.id.clone())
+            .join("widgets")
+            .join("versions")
+            .join(widget_id);
 
         let mut versions = Vec::new();
         let mut stream = store.list(Some(&versions_path));
@@ -1154,11 +1154,11 @@ impl App {
             .as_generic();
 
         let meta_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("metadata")
-            .child("widgets")
-            .child(widget_id)
-            .child(format!("{}.meta", language));
+            .join(self.id.clone())
+            .join("metadata")
+            .join("widgets")
+            .join(widget_id)
+            .join(format!("{}.meta", language));
 
         let proto_metadata = meta.to_proto();
         compress_to_file(store, meta_path, &proto_metadata).await?;
@@ -1177,21 +1177,21 @@ impl App {
 
         let language = language.unwrap_or_else(|| "en".to_string());
         let meta_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("metadata")
-            .child("widgets")
-            .child(widget_id)
-            .child(format!("{}.meta", language));
+            .join(self.id.clone())
+            .join("metadata")
+            .join("widgets")
+            .join(widget_id)
+            .join(format!("{}.meta", language));
 
         let metadata = from_compressed::<proto::Metadata>(store.clone(), meta_path).await;
         if let Err(e) = metadata {
             eprintln!("Failed to get widget metadata: {}", e);
             let meta_path = Path::from("apps")
-                .child(self.id.clone())
-                .child("metadata")
-                .child("widgets")
-                .child(widget_id)
-                .child("en.meta");
+                .join(self.id.clone())
+                .join("metadata")
+                .join("widgets")
+                .join(widget_id)
+                .join("en.meta");
             let metadata = from_compressed::<proto::Metadata>(store, meta_path).await;
             if let Err(e) = metadata {
                 eprintln!("Failed to get widget metadata in English: {}", e);
@@ -1232,11 +1232,11 @@ impl App {
             .as_generic();
 
         let meta_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("metadata")
-            .child("pages")
-            .child(page_id)
-            .child(format!("{}.meta", language));
+            .join(self.id.clone())
+            .join("metadata")
+            .join("pages")
+            .join(page_id)
+            .join(format!("{}.meta", language));
 
         let proto_metadata = meta.to_proto();
         compress_to_file(store, meta_path, &proto_metadata).await?;
@@ -1255,21 +1255,21 @@ impl App {
 
         let language = language.unwrap_or_else(|| "en".to_string());
         let meta_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("metadata")
-            .child("pages")
-            .child(page_id)
-            .child(format!("{}.meta", language));
+            .join(self.id.clone())
+            .join("metadata")
+            .join("pages")
+            .join(page_id)
+            .join(format!("{}.meta", language));
 
         let metadata = from_compressed::<proto::Metadata>(store.clone(), meta_path).await;
         if let Err(e) = metadata {
             eprintln!("Failed to get page metadata: {}", e);
             let meta_path = Path::from("apps")
-                .child(self.id.clone())
-                .child("metadata")
-                .child("pages")
-                .child(page_id)
-                .child("en.meta");
+                .join(self.id.clone())
+                .join("metadata")
+                .join("pages")
+                .join(page_id)
+                .join("en.meta");
             let metadata = from_compressed::<proto::Metadata>(store, meta_path).await;
             if let Err(e) = metadata {
                 eprintln!("Failed to get page metadata in English: {}", e);
@@ -1316,8 +1316,8 @@ impl App {
             .as_generic();
 
         let manifest_path = Path::from("apps")
-            .child(self.id.clone())
-            .child("manifest.app");
+            .join(self.id.clone())
+            .join("manifest.app");
 
         let mut proto_app = self.to_proto();
         let mut seen = std::collections::HashSet::with_capacity(self.boards.len());
@@ -1491,7 +1491,7 @@ mod tests {
             .await
             .expect("template should instantiate");
         let board = Board::load(
-            Path::from("apps").child(app.id.clone()),
+            Path::from("apps").join(app.id.clone()),
             &created.board_id,
             state,
             None,
@@ -1548,7 +1548,7 @@ mod tests {
             .await
             .expect("board payload should instantiate");
         let board = Board::load(
-            Path::from("apps").child(app.id.clone()),
+            Path::from("apps").join(app.id.clone()),
             &created.board_id,
             state,
             None,
@@ -1575,7 +1575,7 @@ mod tests {
             .await
             .expect("detached template should instantiate");
         let board = Board::load(
-            Path::from("apps").child(app.id.clone()),
+            Path::from("apps").join(app.id.clone()),
             &created.board_id,
             state,
             None,

--- a/packages/core/runtime/src/app/sharing.rs
+++ b/packages/core/runtime/src/app/sharing.rs
@@ -332,7 +332,7 @@ impl App {
             .await?
             .as_generic();
 
-        let base = Path::from("apps").child(self.id.clone());
+        let base = Path::from("apps").join(self.id.clone());
         let meta_files = collect_store_files(meta.clone(), &base).await?;
         let storage_files = collect_store_files(storage.clone(), &base).await?;
 
@@ -613,7 +613,7 @@ impl App {
                 if seg.is_empty() {
                     continue;
                 }
-                p = p.child(seg);
+                p = p.join(seg);
             }
             p
         }
@@ -799,7 +799,7 @@ impl App {
         let storage = FlowLikeState::project_storage_store(&app_state)
             .await?
             .as_generic();
-        let base = Path::from("apps").child(manifest.app_id.clone());
+        let base = Path::from("apps").join(manifest.app_id.clone());
 
         #[derive(Default)]
         struct Plan {
@@ -1046,7 +1046,7 @@ mod tests {
     }
 
     async fn seed_sample_objects(meta: &Arc<InMemory>, storage: &Arc<InMemory>, app_id: &str) {
-        let meta_path = ObjectPath::from("apps").child(app_id).child("config.meta");
+        let meta_path = ObjectPath::from("apps").join(app_id).join("config.meta");
         meta.put(
             &meta_path,
             PutPayload::from_bytes(Bytes::from_static(b"meta config")),
@@ -1054,7 +1054,7 @@ mod tests {
         .await
         .expect("seed meta");
 
-        let storage_path = ObjectPath::from("apps").child(app_id).child("data.bin");
+        let storage_path = ObjectPath::from("apps").join(app_id).join("data.bin");
         storage
             .put(
                 &storage_path,
@@ -1358,7 +1358,7 @@ mod tests {
                 .expect("import plain");
             assert_eq!(imported.id, app_id);
 
-            let manifest_path = ObjectPath::from("apps").child(app_id).child("manifest.app");
+            let manifest_path = ObjectPath::from("apps").join(app_id).join("manifest.app");
             let manifest_bytes = import_meta
                 .get(&manifest_path)
                 .await
@@ -1368,7 +1368,7 @@ mod tests {
                 .expect("manifest bytes");
             assert!(!manifest_bytes.is_empty(), "manifest should not be empty");
 
-            let config_path = ObjectPath::from("apps").child(app_id).child("config.meta");
+            let config_path = ObjectPath::from("apps").join(app_id).join("config.meta");
             let config_bytes = import_meta
                 .get(&config_path)
                 .await
@@ -1378,7 +1378,7 @@ mod tests {
                 .expect("config bytes");
             assert_eq!(config_bytes, Bytes::from_static(b"meta config"));
 
-            let storage_path = ObjectPath::from("apps").child(app_id).child("data.bin");
+            let storage_path = ObjectPath::from("apps").join(app_id).join("data.bin");
             let blob_bytes = import_storage
                 .get(&storage_path)
                 .await
@@ -1423,7 +1423,7 @@ mod tests {
             .expect("import enc");
             assert_eq!(imported.id, app_id);
 
-            let manifest_path = ObjectPath::from("apps").child(app_id).child("manifest.app");
+            let manifest_path = ObjectPath::from("apps").join(app_id).join("manifest.app");
             let manifest_bytes = import_meta
                 .get(&manifest_path)
                 .await
@@ -1433,7 +1433,7 @@ mod tests {
                 .expect("manifest bytes");
             assert!(!manifest_bytes.is_empty(), "manifest should not be empty");
 
-            let config_path = ObjectPath::from("apps").child(app_id).child("config.meta");
+            let config_path = ObjectPath::from("apps").join(app_id).join("config.meta");
             let config_bytes = import_meta
                 .get(&config_path)
                 .await
@@ -1443,7 +1443,7 @@ mod tests {
                 .expect("config bytes");
             assert_eq!(config_bytes, Bytes::from_static(b"meta config"));
 
-            let storage_path = ObjectPath::from("apps").child(app_id).child("data.bin");
+            let storage_path = ObjectPath::from("apps").join(app_id).join("data.bin");
             let blob_bytes = import_storage
                 .get(&storage_path)
                 .await

--- a/packages/core/runtime/src/bit.rs
+++ b/packages/core/runtime/src/bit.rs
@@ -521,7 +521,7 @@ async fn presign_media_asset(name: &str, prefix: &Path, store: &FlowLikeStore) -
         return None;
     }
 
-    let path = prefix.child(format!("{name}.webp"));
+    let path = prefix.clone().join(format!("{name}.webp"));
     store
         .sign_cached("GET", &path, MEDIA_URL_TTL)
         .await
@@ -1026,7 +1026,7 @@ impl BitPack {
                 None => continue,
             };
             let file_name = file_name.unwrap();
-            let bit_path = Path::from(bit.hash.clone()).child(file_name);
+            let bit_path = Path::from(bit.hash.clone()).join(file_name);
             let meta = match bits_store.head(&bit_path).await {
                 Ok(meta) => meta,
                 Err(_) => continue,
@@ -1171,7 +1171,7 @@ impl BitPack {
                     break;
                 }
             };
-            let bit_path = Path::from(bit.hash.clone()).child(file_name);
+            let bit_path = Path::from(bit.hash.clone()).join(file_name);
             let metadata = match bits_store.head(&bit_path).await {
                 Ok(metadata) => metadata,
                 Err(_) => {
@@ -1554,7 +1554,7 @@ impl Bit {
         } else {
             &self.dependency_tree_hash
         };
-        let cache_dir = Path::from("deps-cache").child(format!("bit-deps-{}.bin", cache_key));
+        let cache_dir = Path::from("deps-cache").join(format!("bit-deps-{}.bin", cache_key));
 
         let metadata = bits_store.head(&cache_dir).await;
 
@@ -1666,7 +1666,7 @@ impl Bit {
 
     pub fn to_path(&self, file_system: &Arc<LocalObjectStore>) -> Option<PathBuf> {
         let file_name = self.file_name.clone()?;
-        let bit_path = Path::from(self.hash.clone()).child(file_name);
+        let bit_path = Path::from(self.hash.clone()).join(file_name);
         let path = file_system.path_to_filesystem(&bit_path).ok()?;
         Some(path)
     }

--- a/packages/core/runtime/src/credentials.rs
+++ b/packages/core/runtime/src/credentials.rs
@@ -29,10 +29,10 @@ pub(crate) fn db_path_from_base(base_path: &str) -> Path {
     let base = Path::from(base_path);
 
     if base_path.starts_with("users/") {
-        return base.child("db");
+        return base.join("db");
     }
 
-    base.child("storage").child("db")
+    base.join("storage").join("db")
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/packages/core/runtime/src/flow/board.rs
+++ b/packages/core/runtime/src/flow/board.rs
@@ -1388,9 +1388,10 @@ impl Board {
 
         let board_version_path = self
             .board_dir
-            .child("versions")
-            .child(self.id.clone())
-            .child(format!("{}_{}_{}.board", version.0, version.1, version.2));
+            .clone()
+            .join("versions")
+            .join(self.id.clone())
+            .join(format!("{}_{}_{}.board", version.0, version.1, version.2));
 
         match store.head(&board_version_path).await {
             Ok(_) => {
@@ -1851,7 +1852,7 @@ impl Board {
         // object. `open_board` may return a process-local cached board, so an
         // unconditional save here could otherwise overwrite another process's
         // edit made after the immutable snapshot was prepared.
-        let floating_path = self.board_dir.child(format!("{}.board", self.id));
+        let floating_path = self.board_dir.clone().join(format!("{}.board", self.id));
         let (floating_proto, floating_meta): (proto::Board, _) =
             match from_compressed_with_meta(store.clone(), floating_path.clone()).await {
                 Ok(loaded) => loaded,
@@ -2020,8 +2021,8 @@ impl Board {
         let versions_dir = self
             .board_dir
             .clone()
-            .child("versions")
-            .child(self.id.clone());
+            .join("versions")
+            .join(self.id.clone());
 
         let store = match store {
             Some(store) => store,
@@ -2085,10 +2086,11 @@ impl Board {
     pub fn proto_path(board_dir: &Path, id: &str, version: Option<(u32, u32, u32)>) -> Path {
         match version {
             Some((maj, min, pat)) => board_dir
-                .child("versions")
-                .child(id.to_string())
-                .child(format!("{}_{}_{}.board", maj, min, pat)),
-            None => board_dir.child(format!("{}.board", id)),
+                .clone()
+                .join("versions")
+                .join(id.to_string())
+                .join(format!("{}_{}_{}.board", maj, min, pat)),
+            None => board_dir.clone().join(format!("{}.board", id)),
         }
     }
 
@@ -2232,7 +2234,7 @@ impl Board {
     ) -> flow_like_types::Result<PutResult> {
         self.ensure_supported_format()?;
         self.validate_geometry_contracts()?;
-        let to = self.board_dir.child(format!("{}.board", self.id));
+        let to = self.board_dir.clone().join(format!("{}.board", self.id));
         let store = match store {
             Some(store) => store,
             None => {
@@ -2257,7 +2259,7 @@ impl Board {
     /// already the template id, so the pages it is copying from can only be addressed by the id of
     /// the board they came from.
     fn board_pages_dir(&self, board_id: &str) -> Path {
-        self.board_dir.child(format!("_{}", board_id))
+        self.board_dir.clone().join(format!("_{}", board_id))
     }
 
     fn pages_dir(&self) -> Path {
@@ -2265,39 +2267,41 @@ impl Board {
     }
 
     fn page_path(&self, page_id: &str) -> Path {
-        self.pages_dir().child(format!("{}.page", page_id))
+        self.pages_dir().join(format!("{}.page", page_id))
     }
 
     fn versioned_pages_dir(&self, version: (u32, u32, u32)) -> Path {
         self.board_dir
-            .child("versions")
-            .child(self.id.clone())
-            .child(format!("{}_{}_{}", version.0, version.1, version.2))
+            .clone()
+            .join("versions")
+            .join(self.id.clone())
+            .join(format!("{}_{}_{}", version.0, version.1, version.2))
     }
 
     fn versioned_page_path(&self, version: (u32, u32, u32), page_id: &str) -> Path {
         self.versioned_pages_dir(version)
-            .child(format!("{}.page", page_id))
+            .join(format!("{}.page", page_id))
     }
 
     /// `apps/{app_id}/_template_{template_id}` — where a template's page payloads live. Taken as
     /// a free-standing path so callers that never open the template board (`App::delete_template`,
     /// the fork's storage sweep) still get the layout from one place.
     pub fn template_pages_dir(board_dir: &Path, template_id: &str) -> Path {
-        board_dir.child(format!("_template_{}", template_id))
+        board_dir.clone().join(format!("_template_{}", template_id))
     }
 
     fn template_page_path(&self, template_id: &str, page_id: &str) -> Path {
-        Self::template_pages_dir(&self.board_dir, template_id).child(format!("{}.page", page_id))
+        Self::template_pages_dir(&self.board_dir, template_id).join(format!("{}.page", page_id))
     }
 
     /// Root of a template's version archive. Keyed on the **template** id, never the board the
     /// template was cut from: listing, versioned reads and template deletion all look here.
     pub fn versioned_template_dir(board_dir: &Path, template_id: &str) -> Path {
         board_dir
-            .child("templates")
-            .child("versions")
-            .child(template_id)
+            .clone()
+            .join("templates")
+            .join("versions")
+            .join(template_id)
     }
 
     fn versioned_template_path(
@@ -2305,7 +2309,7 @@ impl Board {
         template_id: &str,
         version: (u32, u32, u32),
     ) -> Path {
-        Self::versioned_template_dir(board_dir, template_id).child(format!(
+        Self::versioned_template_dir(board_dir, template_id).join(format!(
             "{}_{}_{}.template",
             version.0, version.1, version.2
         ))
@@ -2313,7 +2317,7 @@ impl Board {
 
     fn versioned_template_pages_dir(&self, template_id: &str, version: (u32, u32, u32)) -> Path {
         Self::versioned_template_dir(&self.board_dir, template_id)
-            .child(format!("{}_{}_{}", version.0, version.1, version.2))
+            .join(format!("{}_{}_{}", version.0, version.1, version.2))
     }
 
     fn versioned_template_page_path(
@@ -2323,7 +2327,7 @@ impl Board {
         page_id: &str,
     ) -> Path {
         self.versioned_template_pages_dir(template_id, version)
-            .child(format!("{}.page", page_id))
+            .join(format!("{}.page", page_id))
     }
 
     async fn get_store(
@@ -2412,7 +2416,7 @@ impl Board {
         match from_compressed::<proto::Page>(store.clone(), canonical.clone()).await {
             Ok(p) => Ok(p.into()),
             Err(canonical_err) => {
-                let legacy = self.board_dir.child(format!("{}.page", page_id));
+                let legacy = self.board_dir.clone().join(format!("{}.page", page_id));
                 match from_compressed_json::<Page>(store.clone(), legacy.clone()).await {
                     Ok(page) => {
                         let proto: proto::Page = page.clone().into();
@@ -2481,7 +2485,7 @@ impl Board {
         let _ = store.delete(&self.page_path(page_id)).await;
         // Also evict any legacy app-level copy so a subsequent load
         // can't resurrect the page through the fallback reader.
-        let legacy = self.board_dir.child(format!("{}.page", page_id));
+        let legacy = self.board_dir.clone().join(format!("{}.page", page_id));
         let _ = store.delete(&legacy).await;
         self.page_ids.retain(|id| id != page_id);
         self.mark_changed();
@@ -2575,7 +2579,7 @@ impl Board {
         dst_dir: &Path,
     ) -> flow_like_types::Result<()> {
         for page_id in page_ids {
-            let src_path = src_dir.child(format!("{}.page", page_id));
+            let src_path = src_dir.clone().join(format!("{}.page", page_id));
             let page_proto: proto::Page =
                 match from_compressed(store.clone(), src_path.clone()).await {
                     Ok(page) => page,
@@ -2589,7 +2593,7 @@ impl Board {
                         continue;
                     }
                 };
-            let dst_path = dst_dir.child(format!("{}.page", page_id));
+            let dst_path = dst_dir.clone().join(format!("{}.page", page_id));
             compress_to_file(store.clone(), dst_path, &page_proto).await?;
         }
         Ok(())
@@ -2609,7 +2613,7 @@ impl Board {
     ) -> flow_like_types::Result<()> {
         self.ensure_supported_format()?;
         self.validate_geometry_contracts()?;
-        let to = self.board_dir.child(format!("{}.template", self.id));
+        let to = self.board_dir.clone().join(format!("{}.template", self.id));
         let store = self.get_store(store).await?;
 
         let mut template = self.clone();
@@ -2732,7 +2736,7 @@ impl Board {
         let board_dir = path.clone();
         let path = match version {
             Some(version) => Self::versioned_template_path(&board_dir, template_id, version),
-            None => path.child(format!("{}.template", template_id)),
+            None => path.join(format!("{}.template", template_id)),
         };
 
         let board: flow_like_types::proto::Board = from_compressed(store, path).await?;

--- a/packages/core/runtime/src/flow/compiled/mod.rs
+++ b/packages/core/runtime/src/flow/compiled/mod.rs
@@ -56,14 +56,17 @@ const MAX_DECOMPRESSED_LEN: usize = 512 * 1024 * 1024;
 
 /// Directory holding a board's version artifacts (compiled board + prerun manifest).
 fn version_artifact_dir(board_dir: &Path, board_id: &str) -> Path {
-    board_dir.child("compiled").child(board_id.to_string())
+    board_dir
+        .clone()
+        .join("compiled")
+        .join(board_id.to_string())
 }
 
 /// Compiled artifact of an immutable board version. Lives beside the version
 /// snapshots inside the app's meta prefix, so deleting the app removes it.
 pub fn artifact_path(board_dir: &Path, board_id: &str, version: (u32, u32, u32)) -> Path {
     version_artifact_dir(board_dir, board_id)
-        .child(format!("{}_{}_{}.flcb", version.0, version.1, version.2))
+        .join(format!("{}_{}_{}.flcb", version.0, version.1, version.2))
 }
 
 /// Directory holding a board's content-addressed draft artifacts.
@@ -75,11 +78,11 @@ pub fn artifact_path(board_dir: &Path, board_id: &str, version: (u32, u32, u32))
 /// sweep removes old entries from local stores, which have no lifecycle rules.
 pub fn draft_artifact_dir(app_id: &str, board_id: &str) -> Path {
     Path::from("tmp")
-        .child("apps")
-        .child(app_id)
-        .child("compiled")
-        .child("drafts")
-        .child(board_id)
+        .join("apps")
+        .join(app_id)
+        .join("compiled")
+        .join("drafts")
+        .join(board_id)
 }
 
 /// Compiled artifact of a floating draft, keyed by the source `.board`'s ETag
@@ -93,7 +96,7 @@ pub fn draft_artifact_path(
     registry_fingerprint: &[u8; 32],
 ) -> Path {
     let fingerprint = blake3::Hash::from_bytes(*registry_fingerprint).to_hex();
-    draft_artifact_dir(app_id, board_id).child(format!(
+    draft_artifact_dir(app_id, board_id).join(format!(
         "{}_{}.flcb",
         draft_artifact_stem(e_tag),
         &fingerprint.as_str()[..16]
@@ -104,7 +107,7 @@ pub fn draft_artifact_path(
 /// `.board` object that produced it. This lets an executor rebuild an exact
 /// artifact after the floating source advances.
 pub fn draft_source_path(app_id: &str, board_id: &str, e_tag: &str) -> Path {
-    draft_artifact_dir(app_id, board_id).child(format!("{}.board", draft_artifact_stem(e_tag)))
+    draft_artifact_dir(app_id, board_id).join(format!("{}.board", draft_artifact_stem(e_tag)))
 }
 
 /// File stem shared by every draft artifact of one `.board` etag.

--- a/packages/core/runtime/src/flow/compiled/prerun.rs
+++ b/packages/core/runtime/src/flow/compiled/prerun.rs
@@ -2718,7 +2718,7 @@ fn permission_string(permission: &NodePermission) -> String {
 /// serving and repairing its legacy artifact during a rolling deployment
 /// without overwriting authority minted by a newer Lambda.
 pub fn manifest_path(board_dir: &Path, board_id: &str, version: (u32, u32, u32)) -> Path {
-    super::version_artifact_dir(board_dir, board_id).child(format!(
+    super::version_artifact_dir(board_dir, board_id).join(format!(
         "{}_{}_{}.v{MANIFEST_FORMAT_VERSION}.prerun",
         version.0, version.1, version.2
     ))
@@ -2730,7 +2730,7 @@ pub fn manifest_path(board_dir: &Path, board_id: &str, version: (u32, u32, u32))
 /// hint while old Lambdas in a rolling deployment continue using it.
 pub fn legacy_manifest_path(board_dir: &Path, board_id: &str, version: (u32, u32, u32)) -> Path {
     super::version_artifact_dir(board_dir, board_id)
-        .child(format!("{}_{}_{}.prerun", version.0, version.1, version.2))
+        .join(format!("{}_{}_{}.prerun", version.0, version.1, version.2))
 }
 
 /// Page execution manifest of an immutable board version.
@@ -2750,7 +2750,7 @@ pub fn version_page_manifest_path(
     hash_string(&mut hasher, page_id);
     hash_string(&mut hasher, page_revision);
     let page_key = hasher.finalize().to_hex();
-    super::version_artifact_dir(board_dir, board_id).child(format!(
+    super::version_artifact_dir(board_dir, board_id).join(format!(
         "{}_{}_{}.v{MANIFEST_FORMAT_VERSION}.{}.page.prerun",
         version.0,
         version.1,
@@ -2763,7 +2763,7 @@ pub fn version_page_manifest_path(
 /// by the same `.board` etag.
 pub fn draft_manifest_path(app_id: &str, board_id: &str, e_tag: &str) -> Path {
     super::draft_artifact_dir(app_id, board_id)
-        .child(format!("{}.prerun", super::draft_artifact_stem(e_tag)))
+        .join(format!("{}.prerun", super::draft_artifact_stem(e_tag)))
 }
 
 /// Page-aware prerun manifest for a floating draft. The Board ETag and
@@ -2781,7 +2781,7 @@ pub fn draft_page_manifest_path(
     hash_string(&mut hasher, page_id);
     hash_string(&mut hasher, page_revision);
     let page_key = hasher.finalize().to_hex();
-    super::draft_artifact_dir(app_id, board_id).child(format!(
+    super::draft_artifact_dir(app_id, board_id).join(format!(
         "{}_{}.page.prerun",
         super::draft_artifact_stem(e_tag),
         &page_key.as_str()[..32]

--- a/packages/core/runtime/src/flow/compiled/resolver.rs
+++ b/packages/core/runtime/src/flow/compiled/resolver.rs
@@ -140,7 +140,7 @@ impl TemplateCache {
             ));
         }
         let expected_etag = expected_etag.map(str::trim).filter(|etag| !etag.is_empty());
-        let storage_root = Path::from("apps").child(app_id.to_string());
+        let storage_root = Path::from("apps").join(app_id.to_string());
         let proto_path = Board::proto_path(&storage_root, board_id, version);
 
         let meta_store = state
@@ -404,7 +404,7 @@ pub async fn sweep_draft_artifacts(
 
     let cutoff = chrono::Utc::now()
         - chrono::Duration::from_std(max_age).unwrap_or(chrono::Duration::days(7));
-    let draft_prefix = Path::from("tmp").child("apps");
+    let draft_prefix = Path::from("tmp").join("apps");
     let current_cutoff = cutoff;
     let current = meta_store
         .list(Some(&draft_prefix))
@@ -416,7 +416,7 @@ pub async fn sweep_draft_artifacts(
         .map_ok(|meta| meta.location)
         .boxed();
 
-    let legacy_prefix = Path::from("tmp").child("compiled");
+    let legacy_prefix = Path::from("tmp").join("compiled");
     let legacy = meta_store
         .list(Some(&legacy_prefix))
         .try_filter(move |meta| futures::future::ready(meta.last_modified < cutoff))

--- a/packages/core/runtime/src/flow/event.rs
+++ b/packages/core/runtime/src/flow/event.rs
@@ -1316,20 +1316,20 @@ impl Event {
     /// under. All path construction goes through these helpers; the layout
     /// literal must exist exactly once.
     fn storage_root(app_id: &str) -> Path {
-        Path::from("apps").child(app_id).child("events")
+        Path::from("apps").join(app_id).join("events")
     }
 
     fn live_path(app_id: &str, event_id: &str) -> Path {
-        Self::storage_root(app_id).child(format!("{event_id}.event"))
+        Self::storage_root(app_id).join(format!("{event_id}.event"))
     }
 
     fn versions_root(app_id: &str, event_id: &str) -> Path {
-        Self::storage_root(app_id).child("versions").child(event_id)
+        Self::storage_root(app_id).join("versions").join(event_id)
     }
 
     fn version_path(app_id: &str, event_id: &str, version: (u32, u32, u32)) -> Path {
         Self::versions_root(app_id, event_id)
-            .child(format!("{}.{}.{}", version.0, version.1, version.2))
+            .join(format!("{}.{}.{}", version.0, version.1, version.2))
     }
 
     pub async fn get_versions(&self, app: &App) -> flow_like_types::Result<Vec<(u32, u32, u32)>> {
@@ -1791,9 +1791,9 @@ mod tests {
             .unwrap()
             .as_generic();
         let live_path = Path::from("apps")
-            .child(app.id.clone())
-            .child("events")
-            .child("evt-upsert.event");
+            .join(app.id.clone())
+            .join("events")
+            .join("evt-upsert.event");
         store
             .put(&live_path, PutPayload::from_static(b"not lz4 protobuf"))
             .await

--- a/packages/core/runtime/src/flow/execution.rs
+++ b/packages/core/runtime/src/flow/execution.rs
@@ -598,8 +598,8 @@ impl Run {
         };
 
         let base_path = Path::from("runs")
-            .child(self.app_id.clone())
-            .child(self.board.id.clone());
+            .join(self.app_id.clone())
+            .join(self.board.id.clone());
         tracing::debug!(path = %base_path, finalize, traces = self.traces.len(), "Preparing log flush");
 
         // 1) pre‑count total logs, reserve once, and find highest level in one pass

--- a/packages/core/runtime/src/flow/execution/context.rs
+++ b/packages/core/runtime/src/flow/execution/context.rs
@@ -186,46 +186,46 @@ impl ExecutionContextCache {
 
     pub fn get_user_dir(&self, node: bool) -> flow_like_types::Result<Path> {
         let base = Path::from("users")
-            .child(self.sub.clone())
-            .child("apps")
-            .child(self.app_id.clone());
+            .join(self.sub.clone())
+            .join("apps")
+            .join(self.app_id.clone());
         if !node {
             return Ok(base);
         }
 
-        Ok(base.child(self.node_id.as_ref()))
+        Ok(base.join(self.node_id.as_ref()))
     }
 
     pub fn get_cache(&self, node: bool, user: bool) -> flow_like_types::Result<Path> {
         let mut base = Path::from("tmp");
 
         if user {
-            base = base.child("user").child(self.sub.clone());
+            base = base.join("user").join(self.sub.clone());
         } else {
-            base = base.child("global");
+            base = base.join("global");
         }
 
-        base = base.child("apps").child(self.app_id.clone());
+        base = base.join("apps").join(self.app_id.clone());
 
         if !node {
             return Ok(base);
         }
 
-        Ok(base.child(self.node_id.as_ref()))
+        Ok(base.join(self.node_id.as_ref()))
     }
 
     pub fn get_storage(&self, node: bool) -> flow_like_types::Result<Path> {
-        let base = self.board_dir.child("storage");
+        let base = self.board_dir.clone().join("storage");
 
         if !node {
             return Ok(base);
         }
 
-        Ok(base.child(self.node_id.as_ref()))
+        Ok(base.join(self.node_id.as_ref()))
     }
 
     pub fn get_upload_dir(&self) -> flow_like_types::Result<Path> {
-        let base = self.board_dir.child("upload");
+        let base = self.board_dir.clone().join("upload");
         Ok(base)
     }
 }

--- a/packages/core/runtime/src/flow/execution/rejection.rs
+++ b/packages/core/runtime/src/flow/execution/rejection.rs
@@ -264,7 +264,7 @@ impl RejectedRun {
 
 /// Board-level log database path used by every run artifact.
 pub fn runs_base_path(app_id: &str, board_id: &str) -> Path {
-    Path::from("runs").child(app_id).child(board_id)
+    Path::from("runs").join(app_id).join(board_id)
 }
 
 /// Convenience for callers that hold a log-database builder rather than an

--- a/packages/core/runtime/src/flow/regression/suite.rs
+++ b/packages/core/runtime/src/flow/regression/suite.rs
@@ -338,29 +338,29 @@ impl RegressionSuite {
     /// `apps/{app_id}/regression` — the storage root every regression object
     /// lives under.
     fn storage_root(app_id: &str) -> Path {
-        Path::from("apps").child(app_id).child("regression")
+        Path::from("apps").join(app_id).join("regression")
     }
 
     fn suite_path(app_id: &str, suite_id: &str) -> Path {
-        Self::storage_root(app_id).child(format!("{suite_id}.suite"))
+        Self::storage_root(app_id).join(format!("{suite_id}.suite"))
     }
 
     fn fixtures_root(app_id: &str, suite_id: &str) -> Path {
-        Self::storage_root(app_id).child("fixtures").child(suite_id)
+        Self::storage_root(app_id).join("fixtures").join(suite_id)
     }
 
     fn fixture_path(app_id: &str, suite_id: &str, fixture_id: &str) -> Path {
-        Self::fixtures_root(app_id, suite_id).child(format!("{fixture_id}.fixture"))
+        Self::fixtures_root(app_id, suite_id).join(format!("{fixture_id}.fixture"))
     }
 
     /// Desktop-only run archive root; cloud stores runs in Postgres and
     /// writes nothing here.
     pub fn runs_root(app_id: &str, suite_id: &str) -> Path {
-        Self::storage_root(app_id).child("runs").child(suite_id)
+        Self::storage_root(app_id).join("runs").join(suite_id)
     }
 
     pub fn run_archive_path(app_id: &str, suite_id: &str, suite_run_id: &str) -> Path {
-        Self::runs_root(app_id, suite_id).child(format!("{suite_run_id}.run"))
+        Self::runs_root(app_id, suite_id).join(format!("{suite_run_id}.run"))
     }
 
     async fn store(

--- a/packages/core/runtime/src/state.rs
+++ b/packages/core/runtime/src/state.rs
@@ -871,8 +871,8 @@ impl FlowLikeState {
             .as_ref()
             .ok_or_else(|| anyhow!("No log database configured"))?;
         let base_path = Path::from("runs")
-            .child(meta.app_id.clone())
-            .child(meta.board_id.clone());
+            .join(meta.app_id.clone())
+            .join(meta.board_id.clone());
         let db = db_fn(base_path.clone()).execute().await?;
 
         let db = db.open_table(meta.run_id.clone()).execute().await?;
@@ -1193,7 +1193,7 @@ mod tests {
 
     #[test]
     fn object_store_path_serialization() {
-        let path = Path::from("test").child("path").child("one");
+        let path = Path::from("test").join("path").join("one");
         let event = PathBuf::from("random").join(path.to_string());
         assert_eq!(path.to_string(), "test/path/one".to_string());
         assert_eq!(event.to_str().unwrap(), "random/test/path/one");

--- a/packages/core/runtime/src/utils/download.rs
+++ b/packages/core/runtime/src/utils/download.rs
@@ -154,7 +154,7 @@ async fn process_download_bit(
     };
 
     let store_path =
-        Path::from(bit.hash.clone()).child(bit.file_name.clone().ok_or(anyhow!("No file name"))?);
+        Path::from(bit.hash.clone()).join(bit.file_name.clone().ok_or(anyhow!("No file name"))?);
     let path_name = file_store.path_to_filesystem(&store_path)?;
     let temp_extension = path_name
         .extension()

--- a/packages/core/tests/compiled_board_roundtrip.rs
+++ b/packages/core/tests/compiled_board_roundtrip.rs
@@ -43,7 +43,7 @@ fn connect(from: &mut Pin, to: &mut Pin) {
 fn empty_board() -> Board {
     Board::new_detached(
         Some("test-board".to_string()),
-        Path::from("apps").child("test"),
+        Path::from("apps").join("test"),
     )
 }
 
@@ -346,7 +346,7 @@ fn catalog_interning_roundtrips_and_keeps_user_edits() {
     let bytes = encode_artifact(&compiled, &[3u8; 32]).expect("encode");
     let decoded = decode_artifact(&bytes, None).expect("decode");
     let view =
-        reconstruct_board(&decoded, Path::from("apps").child("t"), Some(&registry)).expect("view");
+        reconstruct_board(&decoded, Path::from("apps").join("t"), Some(&registry)).expect("view");
     let restored = &view.nodes["n_demo"];
     assert_eq!(restored.friendly_name, "My renamed demo");
     assert_eq!(restored.description, placed.description);
@@ -360,7 +360,7 @@ fn catalog_interning_roundtrips_and_keeps_user_edits() {
     // Without the catalog, interned fields must fail loudly, not silently
     // reconstruct empty.
     assert!(
-        reconstruct_board(&decoded, Path::from("apps").child("t"), None).is_err(),
+        reconstruct_board(&decoded, Path::from("apps").join("t"), None).is_err(),
         "interned artifact without catalog must be rejected"
     );
 }
@@ -419,7 +419,7 @@ fn reconstructed_view_preserves_execution_fields() {
         .insert("ref_a".to_string(), "{\"type\":\"object\"}".to_string());
 
     let compiled = compile_board(&board).expect("compile");
-    let view = reconstruct_board(&compiled, Path::from("apps").child("app-x"), None).expect("view");
+    let view = reconstruct_board(&compiled, Path::from("apps").join("app-x"), None).expect("view");
 
     assert_eq!(view.id, board.id);
     assert_eq!(view.nodes.len(), 2);
@@ -456,7 +456,7 @@ fn template_from_bytes_rejects_foreign_or_broken_artifacts() {
         .insert("n".into(), node_with_pins("n", "lonely", vec![]));
     let compiled = compile_board(&board).expect("compile");
     let registry = FlowNodeRegistryInner::new(0);
-    let root = Path::from("apps").child("test");
+    let root = Path::from("apps").join("test");
 
     let compiled_with = [1u8; 32];
     let bytes = encode_artifact(&compiled, &compiled_with).expect("encode");

--- a/packages/core/tests/shadow_store_isolation.rs
+++ b/packages/core/tests/shadow_store_isolation.rs
@@ -25,7 +25,7 @@ fn run_meta(shadow: bool) -> RunMeta {
         app_id: "app-1".to_string(),
         model_usage_app_id: None,
         board_id: "board-1".to_string(),
-        board_dir: Path::from("apps").child("app-1"),
+        board_dir: Path::from("apps").join("app-1"),
         sub: "user-1".to_string(),
         stream_state: false,
         environment: ExecutionEnvironment::Local,
@@ -55,7 +55,7 @@ async fn cache_for(shadow: bool, state: &Arc<FlowLikeState>) -> ExecutionContext
 #[tokio::test]
 async fn shadow_context_cannot_write_app_storage_while_a_normal_one_can() {
     let state = state_with_memory_stores();
-    let path = Path::from("apps").child("app-1").child("file.txt");
+    let path = Path::from("apps").join("app-1").join("file.txt");
 
     let normal = cache_for(false, &state).await;
     normal
@@ -111,7 +111,7 @@ async fn shadow_context_cannot_write_app_storage_while_a_normal_one_can() {
         store
             .as_ref()
             .unwrap_or_else(|| panic!("{name} is configured"))
-            .put(&Path::from("tmp").child("scratch.txt"), b"ok".to_vec())
+            .put(&Path::from("tmp").join("scratch.txt"), b"ok".to_vec())
             .await
             .unwrap_or_else(|e| panic!("{name} must stay writable for a shadow run: {e}"));
     }

--- a/packages/executor/src/execute.rs
+++ b/packages/executor/src/execute.rs
@@ -143,7 +143,7 @@ pub(crate) fn template_from_fetched(
     registry: &FlowNodeRegistryInner,
     request: &ExecutionRequest,
 ) -> Result<Arc<CompiledRunTemplate>, ExecutorError> {
-    let storage_root = Path::from("apps").child(request.app_id.clone());
+    let storage_root = Path::from("apps").join(request.app_id.clone());
     let template =
         template_from_bytes(bytes, fingerprint, registry, &storage_root).map_err(|e| {
             let ours = blake3::Hash::from_bytes(*fingerprint).to_hex();
@@ -934,8 +934,8 @@ pub async fn execute(
                 );
                 if let Some(db_fn) = db_fn.as_ref() {
                     let base_path = Path::from("runs")
-                        .child(request.app_id.as_str())
-                        .child(request.board_id.as_str());
+                        .join(request.app_id.as_str())
+                        .join(request.board_id.as_str());
                     tracing::info!(path = %base_path, "Opening log database to flush run metadata");
                     match state
                         .with_lance_session(db_fn(base_path.clone()))
@@ -1647,10 +1647,8 @@ mod shadow_claim_binding_tests {
             .next()
             .expect("the catalog is not empty");
         node.id = "n1".into();
-        let mut board = Board::new_detached(
-            Some(board_id.to_string()),
-            Path::from("apps").child("app-1"),
-        );
+        let mut board =
+            Board::new_detached(Some(board_id.to_string()), Path::from("apps").join("app-1"));
         board.nodes.insert(node.id.clone(), node);
         let compiled = compile_board_with_catalog(&board, registry.as_ref()).expect("compile");
         encode_artifact(&compiled, fingerprint).expect("encode")

--- a/packages/executor/src/streaming.rs
+++ b/packages/executor/src/streaming.rs
@@ -462,8 +462,8 @@ async fn execute_inner(
                 };
                 if let Some(db_fn) = db_fn.as_ref() {
                     let base_path = Path::from("runs")
-                        .child(request.app_id.as_str())
-                        .child(request.board_id.as_str());
+                        .join(request.app_id.as_str())
+                        .join(request.board_id.as_str());
                     match state
                         .with_lance_session(db_fn(base_path.clone()))
                         .execute()

--- a/packages/storage/files/src/store.rs
+++ b/packages/storage/files/src/store.rs
@@ -252,7 +252,7 @@ impl FlowLikeStore {
     }
 
     pub async fn construct_upload(&self, app_id: &str, prefix: &str) -> Result<Path> {
-        let base_path = Path::from("apps").child(app_id).child("upload");
+        let base_path = Path::from("apps").join(app_id).join("upload");
 
         let final_path = prefix
             .split('/')
@@ -260,7 +260,7 @@ impl FlowLikeStore {
             .fold(base_path, |acc, seg| {
                 // Decode URL-encoded segments (e.g., %CC%88 -> combining umlaut)
                 let decoded = decode(seg).unwrap_or(std::borrow::Cow::Borrowed(seg));
-                acc.child(decoded.as_ref())
+                acc.join(decoded.as_ref())
             });
 
         Ok(final_path)
@@ -272,14 +272,14 @@ impl FlowLikeStore {
         app_id: &str,
         prefix: &str,
     ) -> Result<Path> {
-        let base_path = Path::from("users").child(sub).child("apps").child(app_id);
+        let base_path = Path::from("users").join(sub).join("apps").join(app_id);
 
         let final_path = prefix
             .split('/')
             .filter(|s| !s.is_empty())
             .fold(base_path, |acc, seg| {
                 let decoded = decode(seg).unwrap_or(std::borrow::Cow::Borrowed(seg));
-                acc.child(decoded.as_ref())
+                acc.join(decoded.as_ref())
             });
 
         Ok(final_path)
@@ -441,7 +441,7 @@ mod tests {
 
     #[test]
     fn relative_to_strips_the_app_base_and_keeps_nested_paths() {
-        let base = Path::from("apps").child("app-1").child("upload");
+        let base = Path::from("apps").join("app-1").join("upload");
 
         let file = StorageItem::from(Path::from("apps/app-1/upload/logo.jpg")).relative_to(&base);
         assert_eq!(file.location, "logo.jpg");
@@ -450,10 +450,7 @@ mod tests {
             .relative_to(&base);
         assert_eq!(nested.location, "media/inner/logo.jpg");
 
-        let user_base = Path::from("users")
-            .child("sub-1")
-            .child("apps")
-            .child("app-1");
+        let user_base = Path::from("users").join("sub-1").join("apps").join("app-1");
         let user_file = StorageItem::from(Path::from("users/sub-1/apps/app-1/media/logo.jpg"))
             .relative_to(&user_base);
         assert_eq!(user_file.location, "media/logo.jpg");
@@ -461,7 +458,7 @@ mod tests {
 
     #[test]
     fn relative_to_leaves_unrelated_locations_untouched() {
-        let base = Path::from("apps").child("app-1").child("upload");
+        let base = Path::from("apps").join("app-1").join("upload");
 
         let other = StorageItem::from(Path::from("apps/app-2/upload/logo.jpg")).relative_to(&base);
         assert_eq!(other.location, "apps/app-2/upload/logo.jpg");

--- a/packages/wasm/src/host_functions/mod.rs
+++ b/packages/wasm/src/host_functions/mod.rs
@@ -149,28 +149,28 @@ impl StorageContext {
     }
 
     pub fn get_storage_dir(&self, node: bool) -> Path {
-        let base = self.board_dir.child("storage");
+        let base = self.board_dir.clone().join("storage");
         if node {
-            base.child(self.node_id.clone())
+            base.join(self.node_id.clone())
         } else {
             base
         }
     }
 
     pub fn get_upload_dir(&self) -> Path {
-        self.board_dir.child("upload")
+        self.board_dir.clone().join("upload")
     }
 
     pub fn get_cache_dir(&self, node: bool, user: bool) -> Path {
         let mut base = Path::from("tmp");
         if user {
-            base = base.child("user").child(self.sub.clone());
+            base = base.join("user").join(self.sub.clone());
         } else {
-            base = base.child("global");
+            base = base.join("global");
         }
-        base = base.child("apps").child(self.app_id.clone());
+        base = base.join("apps").join(self.app_id.clone());
         if node {
-            base.child(self.node_id.clone())
+            base.join(self.node_id.clone())
         } else {
             base
         }
@@ -178,11 +178,11 @@ impl StorageContext {
 
     pub fn get_user_dir(&self, node: bool) -> Path {
         let base = Path::from("users")
-            .child(self.sub.clone())
-            .child("apps")
-            .child(self.app_id.clone());
+            .join(self.sub.clone())
+            .join("apps")
+            .join(self.app_id.clone());
         if node {
-            base.child(self.node_id.clone())
+            base.join(self.node_id.clone())
         } else {
             base
         }


### PR DESCRIPTION
This commit updates various instances in the codebase where paths were constructed using the `child` method to instead use the `join` method. This change improves code readability and consistency across the project. The modifications span multiple files, including `bit.rs`, `credentials.rs`, `board.rs`, and others, ensuring that all path manipulations adhere to the new standard.