### PR TITLE
Enhance query handling, error management, and component functionality

### DIFF
--- a/apps/desktop/src-tauri/src/functions/app/tables.rs
+++ b/apps/desktop/src-tauri/src/functions/app/tables.rs
@@ -393,7 +393,7 @@ pub async fn db_query(
         flow_like::flow_like_storage::databases::sql_guard::validate_readonly_sql(&sql)
             .map_err(|e| anyhow!("Invalid query SQL: {e}"))?;
         let context = SessionContext::new();
-        flow_like_storage::geometry::register_geo_functions(&context);
+        flow_like::flow_like_storage::geometry::register_geo_functions(&context);
         let fusion = db.to_datafusion().await?;
         context
             .register_table(table_name, fusion)


### PR DESCRIPTION
This pull request makes a minor update to the import path used for registering geometry functions in the `db_query` function. The change ensures that the correct module path is used for the `register_geo_functions` call.

* Updated the import path for `register_geo_functions` to use `flow_like::flow_like_storage::geometry` instead of `flow_like_storage::geometry`, ensuring consistency with the rest of the codebase.