### PR TITLE
Add native dependency checks and enhance profile synchronization

### DIFF
--- a/.github/scripts/check-container-native-deps.sh
+++ b/.github/scripts/check-container-native-deps.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+recipe="${1:?Pass a Dockerfile with build-deps and runtime-deps stages}"
+platform="${2:-linux/amd64}"
+check_recipe="$(mktemp)"
+trap 'rm -f "$check_recipe"' EXIT
+
+# Extend the actual recipe so this checks its packages and compatibility object.
+# BuildKit skips the unrelated stages that compile the complete application.
+cat "$repo_root/$recipe" > "$check_recipe"
+cat >> "$check_recipe" <<'DOCKERFILE'
+
+FROM build-deps AS native-deps-check-build
+COPY .github/scripts/tests/container-native-deps.c /tmp/native-deps-check.c
+RUN libraries="wayland-client wayland-server libpipewire-0.3 egl gbm xcb-randr xcb-render x11 xi xtst libinput libudev xkbcommon" \
+    && cc -O2 /tmp/native-deps-check.c /tmp/ort-glibc-compat.o -o /tmp/native-deps-check \
+       $(pkg-config --cflags --libs $libraries) -ldl -Wl,--no-as-needed -lstdc++ \
+    && clang_library=$(find /usr/lib -name libclang.so.1 -print -quit) \
+    && test -n "$clang_library" \
+    && /tmp/native-deps-check "$clang_library" \
+    && protoc --version
+
+FROM runtime-deps AS native-deps-check-runtime
+COPY --from=native-deps-check-build /tmp/native-deps-check /tmp/native-deps-check
+RUN /tmp/native-deps-check
+DOCKERFILE
+
+docker buildx build --platform "$platform" --target native-deps-check-runtime \
+  --output type=cacheonly -f "$check_recipe" "$repo_root"

--- a/.github/scripts/container_publication.py
+++ b/.github/scripts/container_publication.py
@@ -228,6 +228,59 @@ def check_config(path):
     visit(config)
 
 
+def report_secrets(path, compiled_text=False):
+    """Summarize scanner metadata without exposing matches or source paths."""
+    try:
+        report = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise PublicationError("secret scan report is unavailable or invalid") from error
+    if not isinstance(report, dict):
+        raise PublicationError("secret scan report has an invalid structure")
+    results = report.get("Results", [])
+    if results is None:
+        results = []
+    if not isinstance(results, list):
+        raise PublicationError("secret scan report has an invalid structure")
+
+    groups = {}
+    for result in results:
+        if not isinstance(result, dict):
+            raise PublicationError("secret scan report has an invalid structure")
+        secrets = result.get("Secrets", [])
+        if secrets is None:
+            secrets = []
+        if not isinstance(secrets, list):
+            raise PublicationError("secret scan report has an invalid structure")
+        scan_file = None
+        target = result.get("Target")
+        if compiled_text and isinstance(target, str):
+            # Only inspect_archive's numeric output names may appear in logs.
+            match = re.fullmatch(r"(?:.*/)?([0-9]{6}\.txt)", target)
+            if match:
+                scan_file = match[1]
+        for secret in secrets:
+            if not isinstance(secret, dict):
+                raise PublicationError("secret scan report has an invalid structure")
+            rule = secret.get("RuleID")
+            if not isinstance(rule, str) or not re.fullmatch(r"[a-z0-9][a-z0-9-]{0,79}", rule):
+                rule = "UNKNOWN"
+            severity = secret.get("Severity")
+            if not isinstance(severity, str) or severity not in {"UNKNOWN", "LOW", "MEDIUM", "HIGH", "CRITICAL"}:
+                severity = "UNKNOWN"
+            entry = {"rule_id": rule, "severity": severity}
+            if scan_file is not None:
+                entry["scan_file"] = scan_file
+                start, end = secret.get("StartLine"), secret.get("EndLine")
+                if type(start) is int and type(end) is int and 0 < start <= end:
+                    entry.update(start_line=start, end_line=end)
+            key = tuple(entry.items())
+            if key not in groups:
+                groups[key] = {**entry, "count": 0}
+            groups[key]["count"] += 1
+    findings = list(groups.values())
+    return {"secret_findings": sum(entry["count"] for entry in findings), "findings": findings}
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
@@ -237,10 +290,15 @@ def main(argv=None):
     extract.add_argument("--output-dir", type=Path, required=True)
     config = commands.add_parser("check-config", help="reject literal credential fields in the embedded API config")
     config.add_argument("--path", type=Path, required=True)
+    report = commands.add_parser("report-secrets", help="summarize secret scan metadata without matched content")
+    report.add_argument("--path", type=Path, required=True)
+    report.add_argument("--compiled-text", action="store_true", help="include generated scan file IDs and line numbers")
     args = parser.parse_args(argv)
     try:
         if args.command == "extract":
             print(json.dumps(extract_image(args.image, args.platform, args.output_dir), sort_keys=True))
+        elif args.command == "report-secrets":
+            print(json.dumps(report_secrets(args.path, args.compiled_text), sort_keys=True))
         else:
             check_config(args.path)
             print("Configuration credential-field check passed.")

--- a/.github/scripts/public_secret_fixtures.py
+++ b/.github/scripts/public_secret_fixtures.py
@@ -18,7 +18,7 @@ import tempfile
 FIXTURE_FILE = Path(__file__).with_suffix(".json")
 CHUNK_SIZE = 64 * 1024
 
-# Rust places these literals from packages/core/editor/src/flow/copilot/stream.rs
+# Older builds placed these literals from packages/core/editor/src/flow/copilot/stream.rs
 # next to each other in the AWS API binary: redact_private_key_blocks (END),
 # redact_known_secret_tokens (xoxp-), and redact_inline_secret_values (markers).
 # Trivy mistakes the prefix plus the following markers for a Slack token.

--- a/.github/scripts/tests/container-native-deps.c
+++ b/.github/scripts/tests/container-native-deps.c
@@ -1,0 +1,57 @@
+#define _GNU_SOURCE
+#include <EGL/egl.h>
+#include <X11/Xlib.h>
+#include <X11/extensions/XInput2.h>
+#include <X11/extensions/XTest.h>
+#include <dlfcn.h>
+#include <gbm.h>
+#include <libinput.h>
+#include <libudev.h>
+#include <pipewire/pipewire.h>
+#include <stdio.h>
+#include <wayland-client.h>
+#include <wayland-server.h>
+#include <xcb/randr.h>
+#include <xcb/render.h>
+#include <xkbcommon/xkbcommon.h>
+
+extern long __isoc23_strtol(const char *, char **, int);
+extern void __cxa_call_terminate(void *);
+
+/* Keep relocations for each native dependency without requiring a display. */
+static void *volatile symbols[] = {
+    (void *)wl_display_connect,
+    (void *)wl_display_create,
+    (void *)pw_get_library_version,
+    (void *)eglGetDisplay,
+    (void *)gbm_create_device,
+    (void *)xcb_randr_query_version,
+    (void *)xcb_render_query_version,
+    (void *)XOpenDisplay,
+    (void *)XIQueryVersion,
+    (void *)XTestQueryExtension,
+    (void *)libinput_path_create_context,
+    (void *)udev_new,
+    (void *)xkb_context_new,
+    (void *)__cxa_call_terminate,
+};
+
+int main(int argc, char **argv) {
+    for (unsigned i = 0; i < sizeof(symbols) / sizeof(symbols[0]); i++) {
+        if (symbols[i] == NULL) return 1;
+    }
+    char *end;
+    if (__isoc23_strtol("123", &end, 10) != 123 || *end != '\0') return 1;
+
+    /* PipeWire's build script loads libclang through bindgen. */
+    if (argc > 1) {
+        void *clang = dlopen(argv[1], RTLD_NOW);
+        if (clang == NULL || dlsym(clang, "clang_createIndex") == NULL) {
+            fprintf(stderr, "Cannot load libclang: %s\n", dlerror());
+            return 1;
+        }
+        dlclose(clang);
+    }
+    puts("Native capture, input and ONNX compatibility dependencies passed.");
+    return 0;
+}

--- a/.github/scripts/tests/test_container_publication.py
+++ b/.github/scripts/tests/test_container_publication.py
@@ -162,6 +162,105 @@ class ConfigTests(unittest.TestCase):
                     publication.check_config(path)
 
 
+class SecretReportTests(unittest.TestCase):
+    def summarize(self, value, compiled_text=False):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "report.json"
+            path.write_text(json.dumps(value))
+            return publication.report_secrets(path, compiled_text)
+
+    def test_report_contains_only_safe_metadata_and_groups_identical_findings(self):
+        secret = {
+            "RuleID": "private-key", "Severity": "HIGH", "StartLine": 12, "EndLine": 30,
+            "Match": "secret-match", "Code": {"Lines": [{"Content": "secret-code"}]},
+            "Title": "secret-title", "AdditionalMetadata": "secret-metadata",
+        }
+        report = {
+            "ArtifactName": "secret-image-name", "Metadata": {"Env": ["PASSWORD=secret-env"]},
+            "Results": [{"Target": "/secret-parent-path/000002.txt", "Secrets": [secret, secret]}],
+        }
+        self.assertEqual(self.summarize(report, compiled_text=True), {
+            "secret_findings": 2,
+            "findings": [{
+                "rule_id": "private-key", "severity": "HIGH", "scan_file": "000002.txt",
+                "start_line": 12, "end_line": 30, "count": 2,
+            }],
+        })
+        self.assertEqual(self.summarize(report), {
+            "secret_findings": 2,
+            "findings": [{"rule_id": "private-key", "severity": "HIGH", "count": 2}],
+        })
+
+    def test_source_paths_and_unvalidated_metadata_are_not_printed(self):
+        for target in ("/app/private-source.rs", "000001.txt\nsecret-path", "secret-000001.txt"):
+            with self.subTest(target=target):
+                self.assertEqual(self.summarize({"Results": [{
+                    "Target": target,
+                    "Secrets": [{
+                        "RuleID": "::warning::secret-rule", "Severity": "secret-severity",
+                        "StartLine": "secret-line", "EndLine": "secret-line",
+                        "Match": "secret-match",
+                    }],
+                }]}, compiled_text=True), {
+                    "secret_findings": 1,
+                    "findings": [{"rule_id": "UNKNOWN", "severity": "UNKNOWN", "count": 1}],
+                })
+
+    def test_generated_files_retain_separate_findings_and_only_valid_line_numbers(self):
+        for start, end in ((True, 2), (1, False), (0, 1), (2, 1), (1, "2"), (1.0, 2), (1, None)):
+            with self.subTest(start=start, end=end):
+                summary = self.summarize({"Results": [
+                    {"Target": "000001.txt", "Secrets": [{"RuleID": "private-key", "Severity": "HIGH", "StartLine": start, "EndLine": end}]},
+                    {"Target": "000002.txt", "Secrets": [{"RuleID": "private-key", "Severity": "HIGH", "StartLine": 8, "EndLine": 9}]},
+                ]}, compiled_text=True)
+                self.assertEqual(summary["secret_findings"], 2)
+                self.assertEqual(summary["findings"][0], {
+                    "rule_id": "private-key", "severity": "HIGH", "scan_file": "000001.txt", "count": 1,
+                })
+                self.assertEqual(summary["findings"][1], {
+                    "rule_id": "private-key", "severity": "HIGH", "scan_file": "000002.txt",
+                    "start_line": 8, "end_line": 9, "count": 1,
+                })
+
+    def test_empty_scan_results_have_zero_findings(self):
+        for report in ({}, {"Results": None}, {"Results": []}, {"Results": [{"Secrets": None}]}):
+            with self.subTest(report=report):
+                self.assertEqual(self.summarize(report), {"secret_findings": 0, "findings": []})
+
+    def test_invalid_report_structure_is_rejected_without_echoing_contents(self):
+        for report in (
+            "secret-value", {"Results": "secret-value"}, {"Results": {}},
+            {"Results": ["secret-value"]}, {"Results": [{"Secrets": {}}]},
+            {"Results": [{"Secrets": ["secret-value"]}]},
+        ):
+            with self.subTest(report=report), self.assertRaisesRegex(publication.PublicationError, "invalid structure") as error:
+                self.summarize(report)
+            self.assertNotIn("secret-value", str(error.exception))
+
+    def test_report_cli_emits_only_summary_and_safe_parse_errors(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "report.json"
+            path.write_text(json.dumps({"Results": [{"Secrets": [{
+                "RuleID": "private-key", "Severity": "HIGH", "Match": "secret-value",
+            }]}]}))
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                self.assertEqual(publication.main(["report-secrets", "--path", str(path)]), 0)
+            self.assertEqual(json.loads(stdout.getvalue()), {
+                "secret_findings": 1,
+                "findings": [{"rule_id": "private-key", "severity": "HIGH", "count": 1}],
+            })
+            for content in ("secret-value", None):
+                if content is None:
+                    path.unlink()
+                else:
+                    path.write_text(content)
+                stderr = io.StringIO()
+                with contextlib.redirect_stderr(stderr):
+                    self.assertEqual(publication.main(["report-secrets", "--path", str(path)]), 1)
+                self.assertEqual(stderr.getvalue(), "container publication: secret scan report is unavailable or invalid\n")
+
+
 class DockerTests(unittest.TestCase):
     def test_architecture_mismatch_prevents_container_creation(self):
         with patch.object(publication, "docker", return_value="linux/amd64") as docker:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -67,9 +67,39 @@ jobs:
           python3 .github/scripts/container_publication.py check-config --path apps/backend/docker-compose/flow-like.config.example.json
           python3 .github/scripts/container_publication.py check-config --path apps/backend/kubernetes/flow-like.config.example.json
 
+  native-deps:
+    name: Native dependencies (${{ matrix.recipe.name }}, ${{ matrix.platform }})
+    needs: validate
+    strategy:
+      fail-fast: false
+      matrix:
+        recipe:
+          - name: Compose runtime
+            dockerfile: apps/backend/docker-compose/runtime/Dockerfile
+          - name: Kubernetes executor
+            dockerfile: apps/backend/kubernetes/executor/Dockerfile
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.3.0
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+      - name: Compile and run native dependency checks
+        env:
+          DOCKERFILE: ${{ matrix.recipe.dockerfile }}
+          PLATFORM: ${{ matrix.platform }}
+        run: bash .github/scripts/check-container-native-deps.sh "$DOCKERFILE" "$PLATFORM"
+
   matrix:
     name: Select release images
-    needs: validate
+    needs: native-deps
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -180,6 +210,7 @@ jobs:
             --image "$IMAGE" --platform "$PLATFORM" \
             --output-dir "$RUNNER_TEMP/container-binary-strings"
       - name: Scan image files, environment, and history for secrets
+        id: image-secrets
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           version: v0.69.3
@@ -190,7 +221,13 @@ jobs:
           format: json
           output: ${{ runner.temp }}/container-image-secrets.json
           cache: 'false'
+      - name: Summarize failed image secret scan
+        if: failure() && steps.image-secrets.outcome == 'failure'
+        run: |
+          python3 .github/scripts/container_publication.py report-secrets \
+            --path "$RUNNER_TEMP/container-image-secrets.json"
       - name: Scan printable text from compiled binaries for secrets
+        id: binary-secrets
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           version: v0.69.3
@@ -201,6 +238,11 @@ jobs:
           format: json
           output: ${{ runner.temp }}/container-binary-secrets.json
           cache: 'false'
+      - name: Summarize failed compiled-text secret scan
+        if: failure() && steps.binary-secrets.outcome == 'failure'
+        run: |
+          python3 .github/scripts/container_publication.py report-secrets \
+            --path "$RUNNER_TEMP/container-binary-secrets.json" --compiled-text
       - name: Authenticate after publication checks pass
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:

--- a/apps/backend/docker-compose/runtime/Dockerfile
+++ b/apps/backend/docker-compose/runtime/Dockerfile
@@ -2,14 +2,34 @@
 # ============================================================
 # Stage 1: Builder
 # ============================================================
-FROM rust:1.97.1-bookworm AS builder
+FROM rust:1.97.1-bookworm AS build-deps
 
+# Automation execution links the Linux capture and input libraries.
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     protobuf-compiler \
+    libclang-dev \
+    libwayland-dev \
+    libpipewire-0.3-dev \
+    libegl-dev \
+    libgbm-dev \
+    libxcb-randr0-dev \
+    libxcb-render0-dev \
+    libx11-dev \
+    libxi-dev \
+    libxtst-dev \
+    libinput-dev \
+    libudev-dev \
+    libxkbcommon-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# The prebuilt ONNX archive uses glibc/GCC symbols newer than Bookworm provides.
+COPY .github/scripts/ort-glibc-compat.c /tmp/ort-glibc-compat.c
+RUN cc -c -O2 -fPIC /tmp/ort-glibc-compat.c -o /tmp/ort-glibc-compat.o
+ENV RUSTFLAGS="-Clink-arg=/tmp/ort-glibc-compat.o"
+
+FROM build-deps AS builder
 WORKDIR /app
 
 COPY . .
@@ -27,15 +47,30 @@ RUN --mount=type=cache,target=/cargo-home,id=cargo-home,sharing=shared \
 # ============================================================
 # Stage 2: Runtime
 # ============================================================
-FROM debian:bookworm-slim
-
-COPY LICENSE /usr/share/licenses/flow-like/LICENSE
+FROM debian:bookworm-slim AS runtime-deps
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl3 \
     curl \
+    libstdc++6 \
+    libwayland-client0 \
+    libwayland-server0 \
+    libpipewire-0.3-0 \
+    libegl1 \
+    libgbm1 \
+    libxcb-randr0 \
+    libxcb-render0 \
+    libx11-6 \
+    libxi6 \
+    libxtst6 \
+    libinput10 \
+    libudev1 \
+    libxkbcommon0 \
     && rm -rf /var/lib/apt/lists/*
+
+FROM runtime-deps AS runtime
+COPY LICENSE /usr/share/licenses/flow-like/LICENSE
 
 WORKDIR /app
 

--- a/apps/backend/kubernetes/executor/Dockerfile
+++ b/apps/backend/kubernetes/executor/Dockerfile
@@ -2,14 +2,34 @@
 # ============================================================
 # Stage 1: Builder
 # ============================================================
-FROM rust:1.97.1-bookworm AS builder
+FROM rust:1.97.1-bookworm AS build-deps
 
+# Automation execution links the Linux capture and input libraries.
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     protobuf-compiler \
+    libclang-dev \
+    libwayland-dev \
+    libpipewire-0.3-dev \
+    libegl-dev \
+    libgbm-dev \
+    libxcb-randr0-dev \
+    libxcb-render0-dev \
+    libx11-dev \
+    libxi-dev \
+    libxtst-dev \
+    libinput-dev \
+    libudev-dev \
+    libxkbcommon-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# The prebuilt ONNX archive uses glibc/GCC symbols newer than Bookworm provides.
+COPY .github/scripts/ort-glibc-compat.c /tmp/ort-glibc-compat.c
+RUN cc -c -O2 -fPIC /tmp/ort-glibc-compat.c -o /tmp/ort-glibc-compat.o
+ENV RUSTFLAGS="-Clink-arg=/tmp/ort-glibc-compat.o"
+
+FROM build-deps AS builder
 WORKDIR /app
 
 COPY . .
@@ -29,15 +49,30 @@ RUN --mount=type=cache,target=/cargo-home,id=cargo-home,sharing=shared \
 # ============================================================
 # Stage 4: Runtime - minimal for sandboxed execution
 # ============================================================
-FROM debian:bookworm-slim
-
-COPY LICENSE /usr/share/licenses/flow-like/LICENSE
+FROM debian:bookworm-slim AS runtime-deps
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl3 \
+    libstdc++6 \
+    libwayland-client0 \
+    libwayland-server0 \
+    libpipewire-0.3-0 \
+    libegl1 \
+    libgbm1 \
+    libxcb-randr0 \
+    libxcb-render0 \
+    libx11-6 \
+    libxi6 \
+    libxtst6 \
+    libinput10 \
+    libudev1 \
+    libxkbcommon0 \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -r -u 1000 executor
+
+FROM runtime-deps AS runtime
+COPY LICENSE /usr/share/licenses/flow-like/LICENSE
 
 WORKDIR /app
 

--- a/apps/desktop/lib/__tests__/profile-home-sync.test.ts
+++ b/apps/desktop/lib/__tests__/profile-home-sync.test.ts
@@ -66,6 +66,22 @@ describe("profile home synchronization", () => {
 		expect(local.hub_profile.home_layout).toBeNull();
 		expect(local.hub_profile.home_default_id).toBe("team-default");
 	});
+
+	it("keeps a locally saved layout when the hub response omits the home fields", () => {
+		const home_layout = { version: 1 as const, widgets: [] };
+		const local = toLocalProfile({
+			...profile,
+			home_layout,
+			home_default_id: "template",
+		});
+		mergeRemoteProfileMetadata(local, {
+			...profile,
+			updated_at: "2026-09-05T10:02:00Z",
+		});
+		expect(local.hub_profile.home_layout).toEqual(home_layout);
+		expect(local.hub_profile.home_default_id).toBe("template");
+		expect(local.hub_profile.updated).toBe("2026-09-05T10:02:00Z");
+	});
 });
 
 describe("profile sync queue", () => {

--- a/apps/desktop/lib/profile-sync.ts
+++ b/apps/desktop/lib/profile-sync.ts
@@ -118,8 +118,14 @@ export function mergeRemoteProfileMetadata(
 		interests: remote.interests ?? [],
 		tags: remote.tags ?? [],
 		theme: remote.theme ?? null,
-		home_layout: remote.home_layout ?? null,
-		home_default_id: remote.home_default_id ?? null,
+		// Hubs without Home support omit these keys. Only an explicit null is a
+		// reset; otherwise the locally saved Home must survive the pull.
+		...(Object.hasOwn(remote, "home_layout")
+			? { home_layout: remote.home_layout ?? null }
+			: {}),
+		...(Object.hasOwn(remote, "home_default_id")
+			? { home_default_id: remote.home_default_id ?? null }
+			: {}),
 		bits: remote.bit_ids ?? [],
 		apps: remote.apps ?? [],
 		hub: remote.hub,

--- a/apps/desktop/src-tauri/gen/apple/flow-like-desktop_iOS/Info.plist
+++ b/apps/desktop/src-tauri/gen/apple/flow-like-desktop_iOS/Info.plist
@@ -23,12 +23,12 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleURLName</key>
+			<string>flow-like</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>flow-like</string>
 			</array>
-			<key>CFBundleURLName</key>
-			<string>flow-like</string>
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>

--- a/apps/desktop/src-tauri/src/functions/ai/copilot/tests/nested_runs.rs
+++ b/apps/desktop/src-tauri/src/functions/ai/copilot/tests/nested_runs.rs
@@ -790,16 +790,12 @@ fn cancelled_direct_sdk_handler_never_starts() {
 #[test]
 fn panicking_direct_sdk_handler_returns_an_error_and_releases_its_activity_lease() {
     let activity = Arc::new(SdkToolActivityRegistry::default());
+    let last_sdk_event_at = tokio::time::Instant::now();
     let observed_activity = activity.clone();
     let handler: copilot_sdk::ToolHandler = Arc::new(move |_name, _args| {
-        assert_eq!(
-            observed_activity
-                .state
-                .lock()
-                .expect("activity state")
-                .active_deadlines
-                .len(),
-            1,
+        assert!(
+            observed_activity.inactivity_deadline(last_sdk_event_at)
+                >= last_sdk_event_at + sdk_tool_handler_watchdog_timeout("ask_user"),
             "the host-side lease must exist before the SDK publishes its tool event"
         );
         panic!("simulated handler panic");
@@ -820,13 +816,9 @@ fn panicking_direct_sdk_handler_returns_an_error_and_releases_its_activity_lease
             .unwrap_or(&result.text_result_for_llm)
             .contains("simulated handler panic")
     );
-    assert!(
-        activity
-            .state
-            .lock()
-            .expect("activity state")
-            .active_deadlines
-            .is_empty(),
+    assert_eq!(
+        activity.inactivity_deadline(last_sdk_event_at),
+        last_sdk_event_at + SDK_EVENT_INACTIVITY_TIMEOUT,
         "panic unwinding must not leave the SDK watchdog extended"
     );
 }

--- a/packages/api/src/routes/profile/get_profiles.rs
+++ b/packages/api/src/routes/profile/get_profiles.rs
@@ -30,6 +30,9 @@ pub struct ProfileResponse {
     #[schema(value_type = Option<Object>)]
     pub shortcuts: Option<serde_json::Value>,
     #[schema(value_type = Option<Object>)]
+    pub home_layout: Option<serde_json::Value>,
+    pub home_default_id: Option<String>,
+    #[schema(value_type = Option<Object>)]
     pub settings: Option<serde_json::Value>,
     pub hub: String,
     pub hubs: Option<Vec<String>>,
@@ -114,6 +117,8 @@ pub async fn get_profiles(
             bit_ids: p.bit_ids.map(Into::into),
             apps: p.apps,
             shortcuts: p.shortcuts,
+            home_layout: p.home_layout,
+            home_default_id: p.home_default_id,
             settings: p.settings,
             hub: p.hub,
             hubs: p.hubs.map(Into::into),

--- a/packages/core/editor/src/flow/copilot/stream.rs
+++ b/packages/core/editor/src/flow/copilot/stream.rs
@@ -447,17 +447,11 @@ fn redact_basic_tokens(text: &str) -> String {
 }
 
 fn redact_known_secret_tokens(text: &str) -> String {
-    const PREFIXES: &[&str] = &[
-        "sk-",
-        "ghp_",
-        "github_pat_",
-        "xoxb-",
-        "xoxp-",
-        "AKIA",
-        "AIza",
-    ];
+    // Keep separators in the binary so scanners cannot combine a token prefix
+    // with an unrelated string that the linker places immediately after it.
+    const PREFIXES: &str = "sk- ghp_ github_pat_ xoxb- xoxp- AKIA AIza ";
     let mut redacted = text.to_string();
-    for prefix in PREFIXES {
+    for prefix in PREFIXES.split_ascii_whitespace() {
         let mut result = String::with_capacity(redacted.len());
         let mut cursor = 0usize;
         while let Some(relative) = redacted[cursor..].find(prefix) {
@@ -1314,6 +1308,31 @@ mod tests {
         assert_eq!(payload["status"], "submitted");
         assert_eq!(payload["tool_call_id"], "internal-full");
         assert!(payload["source"].as_str().unwrap().contains("logInfo"));
+    }
+
+    #[test]
+    fn known_secret_tokens_preserve_boundaries_and_redact_every_prefix() {
+        for prefix in [
+            "sk-",
+            "ghp_",
+            "github_pat_",
+            "xoxb-",
+            "xoxp-",
+            "AKIA",
+            "AIza",
+        ] {
+            let token = format!("{prefix}synthetic-token");
+            for delimiter in [" ", ",", ";", "\"", "'", ")", "}", "]"] {
+                let input = format!("before ({token}{delimiter}after");
+                assert_eq!(
+                    redact_known_secret_tokens(&input),
+                    format!("before (<redacted>{delimiter}after"),
+                );
+            }
+            assert_eq!(redact_known_secret_tokens(&token), "<redacted>");
+            let word = format!("word{token}");
+            assert_eq!(redact_known_secret_tokens(&word), word);
+        }
     }
 
     #[test]


### PR DESCRIPTION
This pull request introduces two major improvements: (1) it adds automated checks and stricter dependency management for native libraries required by our backend containers, and (2) it enhances secret scanning and reporting in our container publication workflow, including a new Python utility for summarizing scan results in a safe, structured way. Additionally, a minor fix is included for user profile synchronization logic in the desktop app.

**Native dependency management and verification:**

* Added multi-stage Dockerfile patterns (`build-deps`, `runtime-deps`, and `runtime`) to both `apps/backend/docker-compose/runtime/Dockerfile` and `apps/backend/kubernetes/executor/Dockerfile`, ensuring all required native libraries for capture, input, and ONNX compatibility are explicitly installed in both build and runtime images. This includes new build steps for a glibc compatibility shim and expanded runtime dependencies. [[1]](diffhunk://#diff-105a032f01638c9224d428af9ffa6328de3b4802db5c0f45d40a8450790b2112L5-R32) [[2]](diffhunk://#diff-105a032f01638c9224d428af9ffa6328de3b4802db5c0f45d40a8450790b2112L30-R74) [[3]](diffhunk://#diff-a0ca63d03b91279a7ea439ec39eda4bdc22c42fc767c3d9cfcffd20bde1bf864L5-R32) [[4]](diffhunk://#diff-a0ca63d03b91279a7ea439ec39eda4bdc22c42fc767c3d9cfcffd20bde1bf864L32-R76)
* Introduced `.github/scripts/check-container-native-deps.sh` and `.github/scripts/tests/container-native-deps.c` to compile and run a native test binary inside the container, verifying that all required libraries are present and compatible. [[1]](diffhunk://#diff-46af9b4e94a30dd8aacb4ac660add6c4da71d2ae02e926ae0eedd61ffe657e58R1-R31) [[2]](diffhunk://#diff-bba5b6fe8be4f2ae43916ff737397df443195aebac760683e4fe626c4223418cR1-R57)
* Updated the GitHub Actions workflow (`.github/workflows/containers.yml`) to add a `native-deps` job that runs these checks on all supported platforms before proceeding with image publication.

**Secret scan reporting and publication workflow:**

* Added a new `report-secrets` command to `.github/scripts/container_publication.py`, which summarizes secret scan results into safe metadata, grouping findings and omitting sensitive content or paths. This is used to safely report scan failures in CI. [[1]](diffhunk://#diff-81c5048398df49728c542c264864fa150f8f59b1bb51523ea2d740b60933a8b0R231-R283) [[2]](diffhunk://#diff-81c5048398df49728c542c264864fa150f8f59b1bb51523ea2d740b60933a8b0R293-R301)
* Updated the workflow to run this summary command after failed Trivy secret scans, for both image files and compiled binary text, ensuring that only safe, structured summaries are output in logs. [[1]](diffhunk://#diff-19560c84548a42e84d08fea824c8d1aff05ede2f21a9cb0c5a18ca93791469feR213) [[2]](diffhunk://#diff-19560c84548a42e84d08fea824c8d1aff05ede2f21a9cb0c5a18ca93791469feR224-R230) [[3]](diffhunk://#diff-19560c84548a42e84d08fea824c8d1aff05ede2f21a9cb0c5a18ca93791469feR241-R245)
* Added comprehensive tests for the new secret scan summary logic in `.github/scripts/tests/test_container_publication.py`.

**Minor improvements and fixes:**

* Improved documentation in `.github/scripts/public_secret_fixtures.py` for older builds and secret fixture placement.
* Fixed a bug in the desktop app's profile synchronization logic to ensure that locally saved home layouts are preserved if the hub omits those fields.