### PR TITLE
fix: optimize schema resolution and caching in pin matching logic

### DIFF
--- a/packages/ui/lib/flow-board-utils.test.ts
+++ b/packages/ui/lib/flow-board-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { doPinsMatch, parseBoard } from "./flow-board-utils";
 import { GEOMETRY_KINDS, geometryMarker } from "./geometry";
 import type {
@@ -567,6 +567,87 @@ describe("doPinsMatch treats an open-object schema as no schema", () => {
 				{},
 			),
 		).toBe(false);
+	});
+});
+
+describe("doPinsMatch schema classification cache", () => {
+	test("parses a dragged large schema once while scanning fresh candidate pins", () => {
+		const schema = JSON.stringify({
+			type: "object",
+			properties: Object.fromEntries(
+				Array.from({ length: 256 }, (_, index) => [
+					`component_${index}`,
+					{
+						type: "object",
+						properties: {
+							metadata: { type: "object", additionalProperties: true },
+						},
+					},
+				]),
+			),
+		});
+		const output = structPin("element", { schema: "element_ref" });
+		const refs = { element_ref: schema };
+		const originalParse = JSON.parse;
+		const parseSpy = spyOn(JSON, "parse").mockImplementation(originalParse);
+
+		try {
+			for (let index = 0; index < 128; index++) {
+				const input = structPin(`candidate_${index}`, {
+					pin_type: IPinType.Input,
+					schema: OTHER_SCHEMA,
+				});
+				expect(doPinsMatch(output, input, refs)).toBe(false);
+			}
+			expect(
+				parseSpy.mock.calls.filter(([value]) => value === schema),
+			).toHaveLength(1);
+		} finally {
+			parseSpy.mockRestore();
+		}
+	});
+
+	test("reclassifies a pin when its inline schema changes", () => {
+		const output = structPin("element", { schema: OPEN_SCHEMA });
+		const input = structPin("body", {
+			pin_type: IPinType.Input,
+			schema: OTHER_SCHEMA,
+		});
+
+		expect(doPinsMatch(output, input, {})).toBe(true);
+		output.schema = USER_SCHEMA;
+		expect(doPinsMatch(output, input, {})).toBe(false);
+		output.schema = OPEN_SCHEMA;
+		expect(doPinsMatch(output, input, {})).toBe(true);
+	});
+
+	test("reclassifies a pin when its reference changes in place", () => {
+		const output = structPin("element", { schema: "element_ref" });
+		const input = structPin("body", {
+			pin_type: IPinType.Input,
+			schema: OTHER_SCHEMA,
+		});
+		const refs = { element_ref: OPEN_SCHEMA };
+
+		expect(doPinsMatch(output, input, refs)).toBe(true);
+		refs.element_ref = USER_SCHEMA;
+		expect(doPinsMatch(output, input, refs)).toBe(false);
+		refs.element_ref = OPEN_SCHEMA;
+		expect(doPinsMatch(output, input, refs)).toBe(true);
+	});
+
+	test("reclassifies a pin when a new refs map uses the same key", () => {
+		const output = structPin("element", { schema: "element_ref" });
+		const input = structPin("body", {
+			pin_type: IPinType.Input,
+			schema: OTHER_SCHEMA,
+		});
+		const openRefs = { element_ref: OPEN_SCHEMA };
+		const concreteRefs = { element_ref: USER_SCHEMA };
+
+		expect(doPinsMatch(output, input, openRefs)).toBe(true);
+		expect(doPinsMatch(output, input, concreteRefs)).toBe(false);
+		expect(doPinsMatch(output, input, openRefs)).toBe(true);
 	});
 });
 

--- a/packages/ui/lib/flow-board-utils.tsx
+++ b/packages/ui/lib/flow-board-utils.tsx
@@ -411,7 +411,7 @@ const OPEN_OBJECT_SCHEMA_KEYS = new Set(["type", "additionalProperties"]);
  *
  * `{"type":"object","additionalProperties":true}` declares that a pin's shape is open, so it can
  * never contradict a concrete schema and must never be the basis for rejecting a peer pin. The
- * `includes` guard keeps the drag hot path from parsing multi-KB real schemas.
+ * `includes` guard skips schemas without an `additionalProperties` keyword.
  */
 export function isOpenObjectSchema(schema: string): boolean {
 	if (!schema.includes("additionalProperties")) return false;
@@ -428,6 +428,27 @@ export function isOpenObjectSchema(schema: string): boolean {
 	} catch {
 		return false;
 	}
+}
+
+const pinSchemaCache = new WeakMap<
+	IPin,
+	{ schema: string; concreteSchema: string | undefined }
+>();
+
+function resolvePinSchema(
+	pin: IPin,
+	refs: Record<string, string>,
+): string | undefined {
+	if (!pin.schema) return undefined;
+	const schema = refs[pin.schema] ?? pin.schema;
+	const cached = pinSchemaCache.get(pin);
+	if (cached?.schema === schema) return cached.concreteSchema;
+
+	// Catalog filtering compares the dragged pin with thousands of candidate pins.
+	// Classify its schema once, checking the resolved value so ref edits invalidate it.
+	const concreteSchema = isOpenObjectSchema(schema) ? undefined : schema;
+	pinSchemaCache.set(pin, { schema, concreteSchema });
+	return concreteSchema;
 }
 
 export function doPinsMatch(
@@ -489,14 +510,8 @@ export function doPinsMatch(
 
 	// An open-object schema declares that the shape is open, not a contract to match, so it
 	// resolves to "no schema" for every comparison below.
-	const resolveSchema = (pin: IPin) => {
-		if (!pin.schema) return undefined;
-		const resolved = refs[pin.schema] ?? pin.schema;
-		return isOpenObjectSchema(resolved) ? undefined : resolved;
-	};
-
-	const schemaSource = resolveSchema(sourcePin);
-	const schemaTarget = resolveSchema(targetPin);
+	const schemaSource = resolvePinSchema(sourcePin, refs);
+	const schemaTarget = resolvePinSchema(targetPin, refs);
 
 	if (schemaSource && schemaTarget) {
 		if (


### PR DESCRIPTION
This pull request introduces a schema classification cache to optimize the performance of pin compatibility checks in the flow board utilities. The main improvement is caching schema resolution for pins, which avoids redundant parsing and classification during large-scale pin matching operations. Comprehensive tests are added to ensure the cache behaves correctly under schema and reference changes.

**Performance optimization and caching:**

* Introduced a `WeakMap`-based cache (`pinSchemaCache`) to store resolved and classified schemas for each pin, significantly reducing repeated schema parsing during catalog filtering and pin matching.
* Refactored the schema resolution logic in `doPinsMatch` to use the new `resolvePinSchema` function, ensuring that open-object schemas are classified once per pin and reference state.

**Testing and validation:**

* Added a new test suite to `flow-board-utils.test.ts` to verify that large schemas are parsed only once per pin during matching, and to confirm correct cache invalidation when inline schemas or reference maps change.

**Documentation and clarity:**

* Clarified the comment describing the early exit in `isOpenObjectSchema` to specify that the guard skips schemas without the `additionalProperties` keyword, improving code readability.